### PR TITLE
Define core interfaces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.64.0",
         "@mariozechner/pi-ai": "^0.64.0",
+        "@sinclair/typebox": "^0.34.0",
         "just-bash": "^2.14.0",
       },
       "devDependencies": {

--- a/packages/otter-agent/package.json
+++ b/packages/otter-agent/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@mariozechner/pi-agent-core": "^0.64.0",
 		"@mariozechner/pi-ai": "^0.64.0",
+		"@sinclair/typebox": "^0.34.0",
 		"just-bash": "^2.14.0"
 	},
 	"devDependencies": {

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -1,1 +1,27 @@
-export {};
+// OtterAgent interfaces
+export type {
+	AgentEnvironment,
+	AuthStorage,
+	EntryId,
+	SessionManager,
+	ToolDefinition,
+	UIProvider,
+} from "./interfaces/index.js";
+
+// Re-exports from pi-agent-core
+export type {
+	AgentContext,
+	AgentEvent,
+	AgentMessage,
+	AgentState,
+	AgentTool,
+	AgentToolCall,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+	AfterToolCallContext,
+	AfterToolCallResult,
+	BeforeToolCallContext,
+	BeforeToolCallResult,
+	ThinkingLevel,
+	ToolExecutionMode,
+} from "@mariozechner/pi-agent-core";

--- a/packages/otter-agent/src/interfaces/agent-environment.ts
+++ b/packages/otter-agent/src/interfaces/agent-environment.ts
@@ -1,0 +1,34 @@
+import type { ToolDefinition } from "./tool-definition.js";
+
+/**
+ * Represents the environment the agent operates in.
+ *
+ * Replaces the `cwd: string` concept from pi-coding-agent, allowing
+ * agents to work in non-filesystem environments (remote servers, containers,
+ * cloud services, etc.).
+ *
+ * An agent has exactly one environment. Both methods are called once at
+ * startup — they are not dynamic.
+ */
+export interface AgentEnvironment {
+	/**
+	 * Optional string appended to the system message so the agent
+	 * understands the environment it is working in.
+	 *
+	 * @returns A string to append to the system prompt, or `undefined` if
+	 * the environment has nothing to add.
+	 */
+	getSystemMessageAppend(): string | undefined;
+
+	/**
+	 * Tools the environment exposes to the agent for interacting with it.
+	 *
+	 * These are analogous to the built-in tools (read, write, bash, etc.)
+	 * in pi-coding-agent but are fully customisable per environment.
+	 * The returned tools are merged with tools registered by extensions.
+	 *
+	 * @returns An array of tool definitions, or an empty array if the
+	 * environment provides no tools.
+	 */
+	getTools(): ToolDefinition[];
+}

--- a/packages/otter-agent/src/interfaces/auth-storage.ts
+++ b/packages/otter-agent/src/interfaces/auth-storage.ts
@@ -1,0 +1,22 @@
+/**
+ * Minimal interface for credential retrieval.
+ *
+ * The agent loop calls `getApiKey()` before each LLM request to get the
+ * API key for the current provider. All credential management complexity
+ * (OAuth, file storage, environment variables, vaults) is the
+ * implementation's concern.
+ *
+ * Extensions do not interact with AuthStorage.
+ */
+export interface AuthStorage {
+	/**
+	 * Retrieve an API key for the given provider.
+	 *
+	 * Implementations may resolve keys from any source: environment
+	 * variables, files, vaults, OAuth token refresh, etc.
+	 *
+	 * @param provider - The LLM provider identifier (e.g., "anthropic", "openai").
+	 * @returns The API key string, or `undefined` if not available.
+	 */
+	getApiKey(provider: string): Promise<string | undefined>;
+}

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -1,0 +1,5 @@
+export type { AgentEnvironment } from "./agent-environment.js";
+export type { AuthStorage } from "./auth-storage.js";
+export type { SessionManager, EntryId } from "./session-manager.js";
+export type { ToolDefinition } from "./tool-definition.js";
+export type { UIProvider } from "./ui-provider.js";

--- a/packages/otter-agent/src/interfaces/session-manager.ts
+++ b/packages/otter-agent/src/interfaces/session-manager.ts
@@ -1,0 +1,121 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+/**
+ * A unique identifier for a session entry.
+ */
+export type EntryId = string;
+
+/**
+ * Minimal interface for persisting conversation state.
+ *
+ * Follows an append-only model. Does not mandate tree/branching semantics —
+ * a tree-based implementation can be built on top of this interface.
+ *
+ * Every entry gets a unique ID. Manages single-session operations only —
+ * multi-session management (listing, switching, creating) is left to
+ * implementations.
+ */
+export interface SessionManager {
+	/**
+	 * Append an agent message as the next entry in the session.
+	 *
+	 * @param message - The agent message to persist.
+	 * @returns The unique ID of the created entry.
+	 */
+	appendMessage(message: AgentMessage): EntryId;
+
+	/**
+	 * Build the message list to send to the LLM.
+	 *
+	 * Handles compaction: if a compaction marker exists, messages before
+	 * `firstKeptEntryId` are discarded and the compaction summary is
+	 * inserted as an assistant message.
+	 *
+	 * Custom message entries (from `appendCustomMessageEntry`) are included.
+	 * Metadata entries (model change, thinking level, labels) and custom
+	 * entries (from `appendCustomEntry`) are excluded.
+	 *
+	 * @returns An ordered array of messages suitable for the LLM context.
+	 */
+	buildSessionContext(): AgentMessage[];
+
+	/**
+	 * Record a compaction event. When `buildSessionContext()` is called,
+	 * messages before `firstKeptEntryId` will be replaced by the summary.
+	 *
+	 * @param summary - The compaction summary text.
+	 * @param firstKeptEntryId - The ID of the first entry to keep after
+	 *   compaction. All entries before this are replaced by the summary.
+	 * @param details - Optional implementation-specific compaction metadata.
+	 * @returns The unique ID of the compaction entry.
+	 */
+	compact(summary: string, firstKeptEntryId: EntryId, details?: unknown): EntryId;
+
+	/**
+	 * Persist extension state that is NOT included in LLM context.
+	 *
+	 * Used by extensions to store state that survives session reloads.
+	 * On reload, extensions can scan for their `customType` to reconstruct
+	 * internal state.
+	 *
+	 * @param customType - Extension identifier for filtering entries.
+	 * @param data - Optional extension-specific data to persist.
+	 * @returns The unique ID of the created entry.
+	 */
+	appendCustomEntry(customType: string, data?: unknown): EntryId;
+
+	/**
+	 * Persist an extension message that IS included in LLM context.
+	 *
+	 * Unlike `appendCustomEntry`, custom message entries participate in
+	 * the conversation — their `content` is included by `buildSessionContext()`.
+	 *
+	 * @param customType - Extension identifier for filtering entries.
+	 * @param content - The message content sent to the LLM.
+	 * @param display - Whether the message should be shown in the UI.
+	 *   `true` = visible with distinct styling, `false` = hidden.
+	 * @param details - Optional extension-specific metadata (not sent to LLM).
+	 * @returns The unique ID of the created entry.
+	 */
+	appendCustomMessageEntry(
+		customType: string,
+		content: string,
+		display: boolean,
+		details?: unknown,
+	): EntryId;
+
+	/**
+	 * Record a model and thinking level change.
+	 *
+	 * This metadata entry is persisted for session restore but is not
+	 * included in the LLM context.
+	 *
+	 * @param model - The new model identifier.
+	 * @param thinkingLevel - The thinking level at the time of the change.
+	 * @returns The unique ID of the created entry.
+	 */
+	appendModelChange(model: { provider: string; modelId: string }, thinkingLevel: string): EntryId;
+
+	/**
+	 * Record a thinking level change.
+	 *
+	 * This metadata entry is persisted for session restore but is not
+	 * included in the LLM context.
+	 *
+	 * @param thinkingLevel - The new thinking level.
+	 * @returns The unique ID of the created entry.
+	 */
+	appendThinkingLevelChange(thinkingLevel: string): EntryId;
+
+	/**
+	 * Attach a label/bookmark to a specific entry.
+	 *
+	 * Labels are user-defined markers that can be used for navigation
+	 * or bookmarking significant points in the conversation.
+	 *
+	 * @param label - The label text.
+	 * @param targetEntryId - The ID of the entry to label.
+	 * @returns The unique ID of the label entry.
+	 */
+	appendLabel(label: string, targetEntryId: EntryId): EntryId;
+}

--- a/packages/otter-agent/src/interfaces/tool-definition.ts
+++ b/packages/otter-agent/src/interfaces/tool-definition.ts
@@ -1,0 +1,59 @@
+import type { AgentToolResult, AgentToolUpdateCallback } from "@mariozechner/pi-agent-core";
+import type { Static, TSchema } from "@sinclair/typebox";
+
+/**
+ * Definition for a tool that can be registered with the agent.
+ *
+ * Replicated from pi-coding-agent's ToolDefinition with TUI-specific
+ * fields (renderCall, renderResult) removed. The execute signature
+ * uses pi-agent-core's types directly.
+ */
+export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = unknown> {
+	/** Tool name (used in LLM tool calls). */
+	name: string;
+
+	/** Human-readable label for UI display. */
+	label: string;
+
+	/** Description for the LLM explaining what this tool does. */
+	description: string;
+
+	/**
+	 * Optional one-line snippet for the "Available Tools" section in the
+	 * system prompt. Tools without a snippet are omitted from that section.
+	 */
+	promptSnippet?: string;
+
+	/**
+	 * Optional guideline bullets appended to the "Guidelines" section of
+	 * the system prompt when this tool is active.
+	 */
+	promptGuidelines?: string[];
+
+	/** Parameter schema (TypeBox). */
+	parameters: TParams;
+
+	/**
+	 * Optional compatibility shim to prepare raw tool call arguments before
+	 * schema validation. Must return an object conforming to `TParams`.
+	 */
+	prepareArguments?: (args: unknown) => Static<TParams>;
+
+	/**
+	 * Execute the tool.
+	 *
+	 * @param toolCallId - Unique identifier for this tool call.
+	 * @param params - Validated parameters matching the `parameters` schema.
+	 * @param signal - Abort signal for cancellation. Implementations should
+	 *   honour this signal and clean up promptly when aborted.
+	 * @param onUpdate - Optional callback for streaming partial results
+	 *   during long-running tool executions.
+	 * @returns The tool execution result containing content and details.
+	 */
+	execute(
+		toolCallId: string,
+		params: Static<TParams>,
+		signal: AbortSignal | undefined,
+		onUpdate: AgentToolUpdateCallback<TDetails> | undefined,
+	): Promise<AgentToolResult<TDetails>>;
+}

--- a/packages/otter-agent/src/interfaces/ui-provider.ts
+++ b/packages/otter-agent/src/interfaces/ui-provider.ts
@@ -1,0 +1,54 @@
+/**
+ * Optional interface for extension-to-user interaction.
+ *
+ * Provides universal interaction primitives that work regardless of
+ * frontend (TUI, web UI, RPC client). The host application provides
+ * the implementation.
+ *
+ * If no UIProvider is bound, extensions calling these methods should
+ * receive a sensible default (e.g., error or default value).
+ */
+export interface UIProvider {
+	/**
+	 * Show an informational dialog to the user.
+	 *
+	 * @param title - Dialog title.
+	 * @param body - Dialog body text.
+	 */
+	dialog(title: string, body: string): Promise<void>;
+
+	/**
+	 * Show a yes/no confirmation dialog.
+	 *
+	 * @param title - Confirmation title.
+	 * @param body - Confirmation body text.
+	 * @returns `true` if the user confirmed, `false` otherwise.
+	 */
+	confirm(title: string, body: string): Promise<boolean>;
+
+	/**
+	 * Prompt the user for free text input.
+	 *
+	 * @param title - Input prompt title.
+	 * @param placeholder - Optional placeholder text.
+	 * @returns The entered text, or `undefined` if cancelled.
+	 */
+	input(title: string, placeholder?: string): Promise<string | undefined>;
+
+	/**
+	 * Show a selection list for the user to pick from.
+	 *
+	 * @param title - Selection prompt title.
+	 * @param items - The items to choose from.
+	 * @returns The selected item, or `undefined` if cancelled.
+	 */
+	select<T>(title: string, items: T[]): Promise<T | undefined>;
+
+	/**
+	 * Show a transient notification to the user.
+	 *
+	 * @param message - Notification message text.
+	 * @param type - Notification severity. Defaults to "info".
+	 */
+	notify(message: string, type?: "info" | "warning" | "error"): void;
+}


### PR DESCRIPTION
## Summary

- Adds foundational TypeScript interfaces: `AgentEnvironment`, `SessionManager`, `AuthStorage`, `UIProvider`, and `ToolDefinition`
- Sets up pi-agent-core type re-exports from `@otter-agent/core`
- Adds `@sinclair/typebox` as a dependency for `ToolDefinition` parameter schemas

`RpcTransport` is deferred to #6 as its type signature depends on the RPC protocol types.

## Test plan

- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] Types compile with `strict: true`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)