### PR TITLE
feat: implement extension loading, lifecycle, and ModelRegistry

### DIFF
--- a/packages/otter-agent/src/extensions/event-bus-impl.test.ts
+++ b/packages/otter-agent/src/extensions/event-bus-impl.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { createEventBus } from "./event-bus-impl.js";
+
+describe("EventBus", () => {
+	test("emit delivers data to all subscribers on a channel", () => {
+		const bus = createEventBus();
+		const received1: unknown[] = [];
+		const received2: unknown[] = [];
+
+		bus.on("test", (data) => received1.push(data));
+		bus.on("test", (data) => received2.push(data));
+
+		bus.emit("test", { hello: "world" });
+
+		expect(received1).toEqual([{ hello: "world" }]);
+		expect(received2).toEqual([{ hello: "world" }]);
+	});
+
+	test("emit on unknown channel is a no-op", () => {
+		const bus = createEventBus();
+		// Should not throw
+		bus.emit("nonexistent", {});
+	});
+
+	test("unsubscribe removes the handler", () => {
+		const bus = createEventBus();
+		const received: unknown[] = [];
+
+		const unsub = bus.on("ch", (data) => received.push(data));
+		bus.emit("ch", 1);
+		expect(received).toEqual([1]);
+
+		unsub();
+		bus.emit("ch", 2);
+		expect(received).toEqual([1]); // no new delivery
+	});
+
+	test("different channels are independent", () => {
+		const bus = createEventBus();
+		const a: unknown[] = [];
+		const b: unknown[] = [];
+
+		bus.on("a", (data) => a.push(data));
+		bus.on("b", (data) => b.push(data));
+
+		bus.emit("a", "only-a");
+		bus.emit("b", "only-b");
+
+		expect(a).toEqual(["only-a"]);
+		expect(b).toEqual(["only-b"]);
+	});
+
+	test("clear removes all subscriptions", () => {
+		const bus = createEventBus();
+		const received: unknown[] = [];
+
+		bus.on("x", (data) => received.push(data));
+		bus.on("y", (data) => received.push(data));
+
+		bus.clear();
+
+		bus.emit("x", 1);
+		bus.emit("y", 2);
+		expect(received).toEqual([]);
+	});
+
+	test("multiple handlers on the same channel each get their own unsubscribe", () => {
+		const bus = createEventBus();
+		const received: unknown[] = [];
+
+		const unsub1 = bus.on("ch", (data) => received.push(`h1:${data}`));
+		const unsub2 = bus.on("ch", (data) => received.push(`h2:${data}`));
+
+		bus.emit("ch", "a");
+		expect(received).toEqual(["h1:a", "h2:a"]);
+
+		unsub1();
+		bus.emit("ch", "b");
+		expect(received).toEqual(["h1:a", "h2:a", "h2:b"]);
+
+		unsub2();
+		bus.emit("ch", "c");
+		expect(received).toEqual(["h1:a", "h2:a", "h2:b"]);
+	});
+});

--- a/packages/otter-agent/src/extensions/event-bus-impl.ts
+++ b/packages/otter-agent/src/extensions/event-bus-impl.ts
@@ -1,0 +1,38 @@
+/**
+ * EventBus implementation for extension-to-extension communication.
+ */
+import type { EventBus } from "./event-bus.js";
+
+export function createEventBus(): EventBus & { clear(): void } {
+	const handlers = new Map<string, Set<(data: unknown) => void>>();
+
+	return {
+		emit(channel: string, data: unknown): void {
+			const set = handlers.get(channel);
+			if (set) {
+				for (const handler of set) {
+					handler(data);
+				}
+			}
+		},
+
+		on(channel: string, handler: (data: unknown) => void): () => void {
+			let set = handlers.get(channel);
+			if (!set) {
+				set = new Set();
+				handlers.set(channel, set);
+			}
+			set.add(handler);
+			return () => {
+				set.delete(handler);
+				if (set.size === 0) {
+					handlers.delete(channel);
+				}
+			};
+		},
+
+		clear(): void {
+			handlers.clear();
+		},
+	};
+}

--- a/packages/otter-agent/src/extensions/extension-runner.test.ts
+++ b/packages/otter-agent/src/extensions/extension-runner.test.ts
@@ -1,0 +1,836 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ToolDefinition } from "../interfaces/tool-definition.js";
+import { ExtensionRunner } from "./extension-runner.js";
+import type { ExtensionRunnerActions } from "./extension-runner.js";
+import type { Extension } from "./extension.js";
+import type { ExtensionsAPI } from "./extensions-api.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Create a mock set of runner actions. Every method is a mock that returns
+ * a sensible default so tests only need to override what they care about.
+ */
+function createMockActions(): ExtensionRunnerActions {
+	return {
+		registerTool: mock(() => {}),
+		getActiveToolNames: mock(() => []),
+		getAllToolDefinitions: mock(() => []),
+		setActiveToolsByName: mock(() => {}),
+		setModel: mock(async () => true),
+		getThinkingLevel: mock(() => "off" as const),
+		setThinkingLevel: mock(() => {}),
+		sendMessage: mock(() => {}),
+		sendUserMessage: mock(() => {}),
+		appendEntry: mock(() => {}),
+		setLabel: mock(() => {}),
+		getSessionManager: mock(() => ({})),
+		getModel: mock(() => undefined),
+		isIdle: mock(() => true),
+		getSignal: mock(() => undefined),
+		abort: mock(() => {}),
+		hasPendingMessages: mock(() => false),
+		shutdown: mock(() => {}),
+		getContextUsage: mock(() => undefined),
+		compact: mock(() => {}),
+		getSystemPrompt: mock(() => "system prompt"),
+		waitForIdle: mock(async () => {}),
+		reload: mock(async () => {}),
+	};
+}
+
+function createRunner(): ExtensionRunner {
+	const runner = new ExtensionRunner();
+	runner.bindActions(createMockActions());
+	return runner;
+}
+
+/** Capture an extension's API for inspection. */
+function captureApi(): { api: ExtensionsAPI; extension: Extension } {
+	let captured: ExtensionsAPI | undefined;
+	const extension: Extension = (api) => {
+		captured = api;
+	};
+	return {
+		get api() {
+			return captured as ExtensionsAPI;
+		},
+		extension,
+	};
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("ExtensionRunner", () => {
+	// ─── Loading ────────────────────────────────────────────────────
+
+	describe("loading", () => {
+		test("loads a sync extension", async () => {
+			const runner = createRunner();
+			const fn = mock(() => {});
+			await runner.loadExtensions([(api) => fn(api)]);
+
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(fn.mock.calls[0][0]).toBeDefined();
+		});
+
+		test("loads an async extension", async () => {
+			const runner = createRunner();
+			const fn = mock(async () => {});
+			await runner.loadExtensions([async (api) => fn(api)]);
+
+			expect(fn).toHaveBeenCalledTimes(1);
+		});
+
+		test("extension that throws is caught and reported via onError", async () => {
+			const runner = createRunner();
+			const errorListener = mock(() => {});
+			runner.onError(errorListener);
+
+			const good = mock(() => {});
+			const bad: Extension = () => {
+				throw new Error("boom");
+			};
+
+			await runner.loadExtensions([bad, good]);
+
+			expect(good).toHaveBeenCalledTimes(1);
+			expect(errorListener).toHaveBeenCalledTimes(1);
+			expect(errorListener.mock.calls[0][0].message).toBe("boom");
+			expect(errorListener.mock.calls[0][1]).toEqual({ event: "extension_load" });
+		});
+
+		test("loading zero extensions is a no-op", async () => {
+			const runner = createRunner();
+			await runner.loadExtensions([]);
+			// No error, no crash
+		});
+	});
+
+	// ─── Scoped ExtensionsAPI ───────────────────────────────────────
+
+	describe("scoped ExtensionsAPI", () => {
+		test("each extension gets its own ExtensionsAPI instance", async () => {
+			const runner = createRunner();
+			const apis: ExtensionsAPI[] = [];
+
+			await runner.loadExtensions([
+				(api) => {
+					apis.push(api);
+				},
+				(api) => {
+					apis.push(api);
+				},
+			]);
+
+			expect(apis).toHaveLength(2);
+			expect(apis[0]).not.toBe(apis[1]);
+		});
+
+		test("all extensions share the same EventBus", async () => {
+			const runner = createRunner();
+			const buses: unknown[] = [];
+
+			await runner.loadExtensions([
+				(api) => {
+					buses.push(api.events);
+				},
+				(api) => {
+					buses.push(api.events);
+				},
+			]);
+
+			expect(buses).toHaveLength(2);
+			expect(buses[0]).toBe(buses[1]);
+		});
+	});
+
+	// ─── Tool registration ─────────────────────────────────────────
+
+	describe("tool registration", () => {
+		test("extension registerTool calls actions.registerTool", async () => {
+			const mockActions = createMockActions();
+			const runner = new ExtensionRunner();
+			runner.bindActions(mockActions);
+			const tool = {
+				name: "ext_tool",
+				label: "Ext Tool",
+				description: "An extension tool",
+				promptSnippet: "ext_tool",
+				promptGuidelines: [],
+				parameters: {},
+				execute: mock(async () => ({
+					content: [{ type: "text" as const, text: "ok" }],
+					details: undefined,
+				})),
+			};
+
+			await runner.loadExtensions([(api) => api.registerTool(tool as ToolDefinition)]);
+
+			expect(mockActions.registerTool).toHaveBeenCalledWith(tool);
+		});
+	});
+
+	// ─── Fire-and-forget events ────────────────────────────────────
+
+	describe("fire-and-forget events (emit)", () => {
+		test("handlers are called in registration order", async () => {
+			const runner = createRunner();
+			const order: number[] = [];
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("session_start", () => {
+						order.push(1);
+					}),
+				(api) =>
+					api.on("session_start", () => {
+						order.push(2);
+					}),
+			]);
+
+			await runner.emit({ type: "session_start" });
+			expect(order).toEqual([1, 2]);
+		});
+
+		test("errors in one handler do not stop subsequent handlers", async () => {
+			const runner = createRunner();
+			const errorListener = mock(() => {});
+			runner.onError(errorListener);
+			const calls: number[] = [];
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("agent_start", () => {
+						calls.push(1);
+					}),
+				(api) =>
+					api.on("agent_start", () => {
+						throw new Error("oops");
+					}),
+				(api) =>
+					api.on("agent_start", () => {
+						calls.push(2);
+					}),
+			]);
+
+			await runner.emit({ type: "agent_start" });
+			expect(calls).toEqual([1, 2]);
+			expect(errorListener).toHaveBeenCalledTimes(1);
+		});
+
+		test("no handlers is a no-op", async () => {
+			const runner = createRunner();
+			await runner.emit({ type: "session_shutdown" });
+			// No error
+		});
+
+		test("hasHandlers returns true when handlers are registered", async () => {
+			const runner = createRunner();
+			expect(runner.hasHandlers("session_start")).toBe(false);
+
+			await runner.loadExtensions([(api) => api.on("session_start", () => {})]);
+
+			expect(runner.hasHandlers("session_start")).toBe(true);
+		});
+	});
+
+	// ─── tool_call (cancellable) ──────────────────────────────────
+
+	describe("tool_call event", () => {
+		test("no handlers returns undefined", async () => {
+			const runner = createRunner();
+			const result = await runner.emitToolCall({
+				type: "tool_call",
+				toolCallId: "tc1",
+				toolName: "read",
+				input: { path: "/tmp" },
+			});
+			expect(result).toBeUndefined();
+		});
+
+		test("handler that does not block returns undefined", async () => {
+			const runner = createRunner();
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("tool_call", () => {
+						return { block: false };
+					}),
+			]);
+
+			const result = await runner.emitToolCall({
+				type: "tool_call",
+				toolCallId: "tc1",
+				toolName: "read",
+				input: { path: "/tmp" },
+			});
+			expect(result).toBeUndefined();
+		});
+
+		test("handler that blocks returns the block result immediately", async () => {
+			const runner = createRunner();
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("tool_call", () => {
+						return { block: true, reason: "not allowed" };
+					}),
+			]);
+
+			const result = await runner.emitToolCall({
+				type: "tool_call",
+				toolCallId: "tc1",
+				toolName: "rm",
+				input: { path: "/danger" },
+			});
+			expect(result).toEqual({ block: true, reason: "not allowed" });
+		});
+
+		test("first block short-circuits", async () => {
+			const runner = createRunner();
+			const secondCalled = mock(() => {});
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("tool_call", () => {
+						return { block: true, reason: "first" };
+					}),
+				(api) =>
+					api.on("tool_call", () => {
+						secondCalled();
+						return { block: true, reason: "second" };
+					}),
+			]);
+
+			const result = await runner.emitToolCall({
+				type: "tool_call",
+				toolCallId: "tc1",
+				toolName: "rm",
+				input: {},
+			});
+			expect(result).toEqual({ block: true, reason: "first" });
+			expect(secondCalled).not.toHaveBeenCalled();
+		});
+	});
+
+	// ─── tool_result (modifying) ─────────────────────────────────
+
+	describe("tool_result event", () => {
+		test("no handlers returns undefined", async () => {
+			const runner = createRunner();
+			const result = await runner.emitToolResult({
+				type: "tool_result",
+				toolCallId: "tc1",
+				toolName: "read",
+				input: {},
+				content: [{ type: "text", text: "original" }],
+				details: undefined,
+				isError: false,
+			});
+			expect(result).toBeUndefined();
+		});
+
+		test("handler can modify content", async () => {
+			const runner = createRunner();
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("tool_result", () => {
+						return {
+							content: [{ type: "text", text: "modified" }],
+							details: undefined,
+							isError: false,
+						};
+					}),
+			]);
+
+			const result = await runner.emitToolResult({
+				type: "tool_result",
+				toolCallId: "tc1",
+				toolName: "read",
+				input: {},
+				content: [{ type: "text", text: "original" }],
+				details: undefined,
+				isError: false,
+			});
+			expect(result?.content).toEqual([{ type: "text", text: "modified" }]);
+		});
+
+		test("last non-undefined result wins", async () => {
+			const runner = createRunner();
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("tool_result", () => {
+						return {
+							content: [{ type: "text", text: "first" }],
+							details: undefined,
+							isError: false,
+						};
+					}),
+				(api) =>
+					api.on("tool_result", () => {
+						return {
+							content: [{ type: "text", text: "second" }],
+							details: undefined,
+							isError: false,
+						};
+					}),
+			]);
+
+			const result = await runner.emitToolResult({
+				type: "tool_result",
+				toolCallId: "tc1",
+				toolName: "read",
+				input: {},
+				content: [{ type: "text", text: "original" }],
+				details: undefined,
+				isError: false,
+			});
+			expect(result?.content).toEqual([{ type: "text", text: "second" }]);
+		});
+	});
+
+	// ─── input (first-match) ─────────────────────────────────────
+
+	describe("input event", () => {
+		test("no handlers returns undefined", async () => {
+			const runner = createRunner();
+			const result = await runner.emitInput({
+				type: "input",
+				text: "hello",
+				source: "rpc",
+			});
+			expect(result).toBeUndefined();
+		});
+
+		test("continue action does not short-circuit", async () => {
+			const runner = createRunner();
+			const secondCalled = mock(() => ({ action: "handled" as const }));
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("input", () => {
+						return { action: "continue" as const };
+					}),
+				(api) =>
+					api.on("input", () => {
+						return secondCalled();
+					}),
+			]);
+
+			const result = await runner.emitInput({
+				type: "input",
+				text: "hello",
+				source: "rpc",
+			});
+			expect(secondCalled).toHaveBeenCalled();
+			expect(result?.action).toBe("handled");
+		});
+
+		test("transform action returns immediately", async () => {
+			const runner = createRunner();
+			const secondCalled = mock(() => {});
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("input", () => {
+						return { action: "transform" as const, text: "modified" };
+					}),
+				(api) =>
+					api.on("input", () => {
+						secondCalled();
+						return { action: "continue" as const };
+					}),
+			]);
+
+			const result = await runner.emitInput({
+				type: "input",
+				text: "hello",
+				source: "rpc",
+			});
+			expect(secondCalled).not.toHaveBeenCalled();
+			expect(result).toEqual({ action: "transform", text: "modified" });
+		});
+
+		test("handled action returns immediately", async () => {
+			const runner = createRunner();
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("input", () => {
+						return { action: "handled" as const };
+					}),
+			]);
+
+			const result = await runner.emitInput({
+				type: "input",
+				text: "hello",
+				source: "rpc",
+			});
+			expect(result).toEqual({ action: "handled" });
+		});
+	});
+
+	// ─── before_agent_start (chaining) ───────────────────────────
+
+	describe("before_agent_start event", () => {
+		test("no handlers returns undefined", async () => {
+			const runner = createRunner();
+			const result = await runner.emitBeforeAgentStart({
+				type: "before_agent_start",
+				prompt: "hello",
+				systemPrompt: "base prompt",
+			});
+			expect(result).toBeUndefined();
+		});
+
+		test("system prompt overrides chain — last wins", async () => {
+			const runner = createRunner();
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("before_agent_start", () => {
+						return { systemPrompt: "override-1" };
+					}),
+				(api) =>
+					api.on("before_agent_start", () => {
+						return { systemPrompt: "override-2" };
+					}),
+			]);
+
+			const result = await runner.emitBeforeAgentStart({
+				type: "before_agent_start",
+				prompt: "hello",
+				systemPrompt: "base prompt",
+			});
+			expect(result?.systemPrompt).toBe("override-2");
+		});
+
+		test("message fields are merged", async () => {
+			const runner = createRunner();
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("before_agent_start", () => {
+						return {
+							message: {
+								customType: "notice",
+								content: "from ext 1",
+								display: true,
+							},
+						};
+					}),
+				(api) =>
+					api.on("before_agent_start", () => {
+						return { systemPrompt: "new prompt" };
+					}),
+			]);
+
+			const result = await runner.emitBeforeAgentStart({
+				type: "before_agent_start",
+				prompt: "hello",
+				systemPrompt: "base",
+			});
+			expect(result?.message).toEqual({
+				customType: "notice",
+				content: "from ext 1",
+				display: true,
+			});
+			expect(result?.systemPrompt).toBe("new prompt");
+		});
+	});
+
+	// ─── context (modification) ──────────────────────────────────
+
+	describe("context event", () => {
+		test("no handlers returns undefined", async () => {
+			const runner = createRunner();
+			const result = await runner.emitContext({
+				type: "context",
+				messages: [],
+			});
+			expect(result).toBeUndefined();
+		});
+
+		test("handler can modify messages; next handler sees modified messages", async () => {
+			const runner = createRunner();
+			const fakeMsg1 = { role: "user", content: "injected", timestamp: 0 } as AgentMessage;
+			const fakeMsg2 = { role: "user", content: "second", timestamp: 0 } as AgentMessage;
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("context", (event) => {
+						return { messages: [...event.messages, fakeMsg1] };
+					}),
+				(api) =>
+					api.on("context", (event) => {
+						// Should see the injected message
+						return { messages: [...event.messages, fakeMsg2] };
+					}),
+			]);
+
+			const result = await runner.emitContext({
+				type: "context",
+				messages: [],
+			});
+			expect(result?.messages).toHaveLength(2);
+			expect((result?.messages as AgentMessage[])[0]).toBe(fakeMsg1);
+			expect((result?.messages as AgentMessage[])[1]).toBe(fakeMsg2);
+		});
+	});
+
+	// ─── session_before_compact (cancellable) ────────────────────
+
+	describe("session_before_compact event", () => {
+		test("no handlers returns undefined", async () => {
+			const runner = createRunner();
+			const result = await runner.emitSessionBeforeCompact({
+				type: "session_before_compact",
+				messages: [],
+				signal: new AbortController().signal,
+			});
+			expect(result).toBeUndefined();
+		});
+
+		test("cancel short-circuits", async () => {
+			const runner = createRunner();
+			const secondCalled = mock(() => {});
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("session_before_compact", () => {
+						return { cancel: true };
+					}),
+				(api) =>
+					api.on("session_before_compact", () => {
+						secondCalled();
+						return {};
+					}),
+			]);
+
+			const result = await runner.emitSessionBeforeCompact({
+				type: "session_before_compact",
+				messages: [],
+				signal: new AbortController().signal,
+			});
+			expect(result?.cancel).toBe(true);
+			expect(secondCalled).not.toHaveBeenCalled();
+		});
+
+		test("custom compaction short-circuits", async () => {
+			const runner = createRunner();
+
+			await runner.loadExtensions([
+				(api) =>
+					api.on("session_before_compact", () => {
+						return {
+							compaction: {
+								summary: "custom summary",
+								firstKeptEntryId: "entry-42",
+							},
+						};
+					}),
+			]);
+
+			const result = await runner.emitSessionBeforeCompact({
+				type: "session_before_compact",
+				messages: [],
+				signal: new AbortController().signal,
+			});
+			expect(result?.compaction).toEqual({
+				summary: "custom summary",
+				firstKeptEntryId: "entry-42",
+			});
+		});
+	});
+
+	// ─── Commands ────────────────────────────────────────────────
+
+	describe("commands", () => {
+		test("extension can register and execute a command", async () => {
+			const runner = createRunner();
+			const handler = mock(async () => {});
+
+			await runner.loadExtensions([
+				(api) =>
+					api.registerCommand("deploy", {
+						description: "Deploy the app",
+						handler,
+					}),
+			]);
+
+			const commands = runner.getCommands();
+			expect(commands).toHaveLength(1);
+			expect(commands[0].name).toBe("deploy");
+			expect(commands[0].description).toBe("Deploy the app");
+
+			const executed = await runner.executeCommand("deploy", "--prod");
+			expect(executed).toBe(true);
+			expect(handler).toHaveBeenCalledWith("--prod", expect.any(Object));
+		});
+
+		test("executeCommand returns false for unknown command", async () => {
+			const runner = createRunner();
+			const executed = await runner.executeCommand("nonexistent", "");
+			expect(executed).toBe(false);
+		});
+
+		test("command handler errors are caught and reported via onError", async () => {
+			const runner = createRunner();
+			const errorListener = mock(() => {});
+			runner.onError(errorListener);
+
+			await runner.loadExtensions([
+				(api) =>
+					api.registerCommand("fail", {
+						handler: async () => {
+							throw new Error("cmd error");
+						},
+					}),
+			]);
+
+			const executed = await runner.executeCommand("fail", "");
+			expect(executed).toBe(true); // command was found, error was caught internally
+			expect(errorListener).toHaveBeenCalledTimes(1);
+			expect(errorListener.mock.calls[0][0].message).toBe("cmd error");
+			expect(errorListener.mock.calls[0][1]).toEqual({ event: "command:fail" });
+		});
+	});
+
+	// ─── Reload ──────────────────────────────────────────────────
+
+	describe("reload", () => {
+		test("clear removes all handlers and commands", async () => {
+			const runner = createRunner();
+			const handler = mock(() => {});
+
+			await runner.loadExtensions([
+				(api) => api.on("session_start", handler),
+				(api) =>
+					api.registerCommand("test", {
+						handler: async () => {},
+					}),
+			]);
+
+			expect(runner.hasHandlers("session_start")).toBe(true);
+			expect(runner.getCommands()).toHaveLength(1);
+
+			runner.clear();
+
+			expect(runner.hasHandlers("session_start")).toBe(false);
+			expect(runner.getCommands()).toHaveLength(0);
+		});
+
+		test("clear stops events from firing", async () => {
+			const runner = createRunner();
+			const handler = mock(() => {});
+
+			await runner.loadExtensions([(api) => api.on("agent_start", handler)]);
+
+			await runner.emit({ type: "agent_start" });
+			expect(handler).toHaveBeenCalledTimes(1);
+
+			runner.clear();
+
+			await runner.emit({ type: "agent_start" });
+			expect(handler).toHaveBeenCalledTimes(1); // not called again
+		});
+
+		test("re-loading after clear registers fresh handlers", async () => {
+			const runner = createRunner();
+			const handler1 = mock(() => {});
+			const handler2 = mock(() => {});
+
+			await runner.loadExtensions([(api) => api.on("session_start", handler1)]);
+
+			await runner.emit({ type: "session_start" });
+			expect(handler1).toHaveBeenCalledTimes(1);
+
+			runner.clear();
+
+			await runner.loadExtensions([(api) => api.on("session_start", handler2)]);
+
+			await runner.emit({ type: "session_start" });
+			expect(handler1).toHaveBeenCalledTimes(1); // not called again after clear
+			expect(handler2).toHaveBeenCalledTimes(1); // called after reload
+		});
+
+		test("clear also clears the event bus", async () => {
+			const runner = createRunner();
+			let received: unknown | undefined;
+
+			await runner.loadExtensions([
+				(api) => {
+					api.events.on("custom", (data) => {
+						received = data;
+					});
+				},
+			]);
+
+			// Access the shared event bus through a second extension
+			let bus: ExtensionsAPI["events"] | undefined;
+			await runner.loadExtensions([
+				(api) => {
+					bus = api.events;
+				},
+			]);
+
+			bus?.emit("custom", "hello");
+			expect(received).toBe("hello");
+
+			runner.clear();
+			received = undefined;
+			bus?.emit("custom", "world");
+			expect(received).toBeUndefined();
+		});
+	});
+
+	// ─── Error handling ──────────────────────────────────────────
+
+	describe("error handling", () => {
+		test("onError returns unsubscribe function", async () => {
+			const runner = createRunner();
+			const listener1 = mock(() => {});
+			const listener2 = mock(() => {});
+
+			const unsub = runner.onError(listener1);
+			runner.onError(listener2);
+
+			// Trigger an error
+			await runner.loadExtensions([
+				(api) =>
+					api.on("session_start", () => {
+						throw new Error("err");
+					}),
+			]);
+			await runner.emit({ type: "session_start" });
+
+			expect(listener1).toHaveBeenCalledTimes(1);
+			expect(listener2).toHaveBeenCalledTimes(1);
+
+			unsub();
+
+			await runner.emit({ type: "session_start" });
+			expect(listener1).toHaveBeenCalledTimes(1); // not called again
+			expect(listener2).toHaveBeenCalledTimes(2); // still called
+		});
+	});
+
+	// ─── Actions not bound ───────────────────────────────────────
+
+	describe("edge cases", () => {
+		test("emit without bound actions throws", async () => {
+			const runner = new ExtensionRunner();
+			// Don't call bindActions
+
+			// Loading is fine (no actions needed)
+			await runner.loadExtensions([(api) => api.on("session_start", () => {})]);
+
+			// But emitting requires building context, which needs actions
+			await expect(runner.emit({ type: "session_start" })).rejects.toThrow("actions not bound");
+		});
+	});
+});

--- a/packages/otter-agent/src/extensions/extension-runner.ts
+++ b/packages/otter-agent/src/extensions/extension-runner.ts
@@ -1,0 +1,508 @@
+/**
+ * ExtensionRunner — loads extensions and dispatches events to their handlers.
+ *
+ * Each extension gets its own ExtensionsAPI instance. The runner aggregates
+ * all registered handlers and dispatches events in registration order.
+ */
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { Api, ImageContent, Model, TextContent } from "@mariozechner/pi-ai";
+import type { EntryId, ReadonlySessionManager } from "../interfaces/session-manager.js";
+import type { ToolDefinition } from "../interfaces/tool-definition.js";
+import type { UIProvider } from "../interfaces/ui-provider.js";
+import { noOpUIProvider } from "../interfaces/ui.js";
+import type { ModelRegistry } from "../session/model-registry.js";
+import type { CommandInfo, CommandOptions } from "./commands.js";
+import type { CompactOptions, ExtensionCommandContext, ExtensionContext } from "./context.js";
+import { createEventBus } from "./event-bus-impl.js";
+import type { EventBus } from "./event-bus.js";
+import type {
+	BeforeAgentStartEvent,
+	BeforeAgentStartEventResult,
+	BeforeProviderRequestEvent,
+	BeforeProviderRequestEventResult,
+	ContextEvent,
+	ContextEventResult,
+	ExtensionEventName,
+	InputEvent,
+	InputEventResult,
+	SessionBeforeCompactEvent,
+	SessionBeforeCompactResult,
+	ToolCallEvent,
+	ToolCallEventResult,
+	ToolResultEvent,
+	ToolResultEventResult,
+} from "./events.js";
+import type { Extension } from "./extension.js";
+import type { ExtensionHandler, ExtensionsAPI, ToolInfo } from "./extensions-api.js";
+import type { ProviderConfig } from "./providers.js";
+
+// ─── Types ────────────────────────────────────────────────────────────
+
+interface RegisteredCommand {
+	name: string;
+	options: CommandOptions;
+}
+
+type ErrorListener = (error: Error, context: { event?: string; extension?: string }) => void;
+
+/** Actions that the AgentSession provides to the runner. */
+export interface ExtensionRunnerActions {
+	registerTool: (tool: ToolDefinition) => void;
+	getActiveToolNames: () => string[];
+	getAllToolDefinitions: () => ToolDefinition[];
+	setActiveToolsByName: (names: string[]) => void;
+	setModel: (model: Model<Api>) => Promise<boolean>;
+	getThinkingLevel: () => ThinkingLevel;
+	setThinkingLevel: (level: ThinkingLevel) => void;
+	sendMessage: <T = unknown>(
+		message: {
+			customType: string;
+			content: string | (TextContent | ImageContent)[];
+			display: boolean;
+			details?: T;
+		},
+		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+	) => void;
+	sendUserMessage: (
+		content: string | (TextContent | ImageContent)[],
+		options?: { deliverAs?: "steer" | "followUp" },
+	) => void;
+	appendEntry: (customType: string, data?: unknown) => void;
+	setLabel: (entryId: EntryId, label: string | undefined) => void;
+	getSessionManager: () => ReadonlySessionManager;
+	getModel: () => Model<Api> | undefined;
+	isIdle: () => boolean;
+	getSignal: () => AbortSignal | undefined;
+	abort: () => void;
+	hasPendingMessages: () => boolean;
+	shutdown: () => void;
+	getContextUsage: () => ExtensionContext["getContextUsage"] extends () => infer R ? R : never;
+	compact: (options?: CompactOptions) => void;
+	getSystemPrompt: () => string;
+	waitForIdle: () => Promise<void>;
+	reload: () => Promise<void>;
+}
+
+// ─── ExtensionRunner ──────────────────────────────────────────────────
+
+export class ExtensionRunner {
+	private readonly _handlers: Map<string, Array<{ handler: ExtensionHandler<unknown, unknown> }>> =
+		new Map();
+	private readonly _commands: Map<string, RegisteredCommand> = new Map();
+	private readonly _eventBus: EventBus & { clear(): void };
+	private readonly _errorListeners: Set<ErrorListener> = new Set();
+	private _actions: ExtensionRunnerActions | undefined;
+	private _uiProvider: UIProvider;
+	private _modelRegistry: ModelRegistry | undefined;
+
+	constructor() {
+		this._eventBus = createEventBus();
+		this._uiProvider = noOpUIProvider;
+	}
+
+	/** Bind the actions provided by AgentSession. Must be called before dispatching events. */
+	bindActions(actions: ExtensionRunnerActions): void {
+		this._actions = actions;
+	}
+
+	/** Set the UI provider for extension contexts. */
+	setUIProvider(provider: UIProvider): void {
+		this._uiProvider = provider;
+	}
+
+	/** Set the model registry for provider management. */
+	setModelRegistry(registry: ModelRegistry): void {
+		this._modelRegistry = registry;
+	}
+
+	/** Subscribe to extension errors. Returns unsubscribe function. */
+	onError(listener: ErrorListener): () => void {
+		this._errorListeners.add(listener);
+		return () => this._errorListeners.delete(listener);
+	}
+
+	// ─── Extension Loading ────────────────────────────────────────────
+
+	/** Load extensions by calling their factory functions. */
+	async loadExtensions(extensions: Extension[]): Promise<void> {
+		for (const extension of extensions) {
+			const api = this._createExtensionsAPI();
+			try {
+				await extension(api);
+			} catch (err) {
+				this._emitError(err instanceof Error ? err : new Error(String(err)), {
+					event: "extension_load",
+				});
+			}
+		}
+	}
+
+	/** Clear all handlers, commands, and event bus. Used during reload. */
+	clear(): void {
+		this._handlers.clear();
+		this._commands.clear();
+		this._eventBus.clear();
+	}
+
+	// ─── Event Dispatch ───────────────────────────────────────────────
+
+	/** Check if any handlers are registered for an event. */
+	hasHandlers(event: string): boolean {
+		const handlers = this._handlers.get(event);
+		return handlers !== undefined && handlers.length > 0;
+	}
+
+	/** Emit a fire-and-forget event (no return value). */
+	async emit(event: { type: string } & Record<string, unknown>): Promise<void> {
+		const handlers = this._handlers.get(event.type);
+		if (!handlers) return;
+
+		const ctx = this._buildExtensionContext();
+		for (const { handler } of handlers) {
+			try {
+				await handler(event, ctx);
+			} catch (err) {
+				this._emitError(err instanceof Error ? err : new Error(String(err)), {
+					event: event.type,
+				});
+			}
+		}
+	}
+
+	/** Emit a tool_call event. Returns block result if any handler blocks. */
+	async emitToolCall(event: ToolCallEvent): Promise<ToolCallEventResult | undefined> {
+		const handlers = this._handlers.get("tool_call") as
+			| Array<{ handler: ExtensionHandler<ToolCallEvent, ToolCallEventResult> }>
+			| undefined;
+		if (!handlers) return undefined;
+
+		const ctx = this._buildExtensionContext();
+		for (const { handler } of handlers) {
+			try {
+				const result = await handler(event, ctx);
+				if (result?.block) return result;
+			} catch (err) {
+				this._emitError(err instanceof Error ? err : new Error(String(err)), {
+					event: "tool_call",
+				});
+			}
+		}
+		return undefined;
+	}
+
+	/** Emit a tool_result event. Returns modified result if any handler modifies. */
+	async emitToolResult(event: ToolResultEvent): Promise<ToolResultEventResult | undefined> {
+		const handlers = this._handlers.get("tool_result") as
+			| Array<{ handler: ExtensionHandler<ToolResultEvent, ToolResultEventResult> }>
+			| undefined;
+		if (!handlers) return undefined;
+
+		const ctx = this._buildExtensionContext();
+		let lastResult: ToolResultEventResult | undefined;
+		for (const { handler } of handlers) {
+			try {
+				const result = await handler(event, ctx);
+				if (result) lastResult = result;
+			} catch (err) {
+				this._emitError(err instanceof Error ? err : new Error(String(err)), {
+					event: "tool_result",
+				});
+			}
+		}
+		return lastResult;
+	}
+
+	/** Emit an input event. Returns first transform/handled result. */
+	async emitInput(event: InputEvent): Promise<InputEventResult | undefined> {
+		const handlers = this._handlers.get("input") as
+			| Array<{ handler: ExtensionHandler<InputEvent, InputEventResult> }>
+			| undefined;
+		if (!handlers) return undefined;
+
+		const ctx = this._buildExtensionContext();
+		for (const { handler } of handlers) {
+			try {
+				const result = await handler(event, ctx);
+				if (result && result.action !== "continue") return result;
+			} catch (err) {
+				this._emitError(err instanceof Error ? err : new Error(String(err)), {
+					event: "input",
+				});
+			}
+		}
+		return undefined;
+	}
+
+	/** Emit before_agent_start. Collects system prompt overrides and custom messages. */
+	async emitBeforeAgentStart(
+		event: BeforeAgentStartEvent,
+	): Promise<BeforeAgentStartEventResult | undefined> {
+		const handlers = this._handlers.get("before_agent_start") as
+			| Array<{ handler: ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult> }>
+			| undefined;
+		if (!handlers) return undefined;
+
+		const ctx = this._buildExtensionContext();
+		let currentEvent = event;
+		let merged: BeforeAgentStartEventResult | undefined;
+		for (const { handler } of handlers) {
+			try {
+				const result = await handler(currentEvent, ctx);
+				if (result) {
+					if (!merged) merged = {};
+					if (result.message) merged.message = result.message;
+					if (result.systemPrompt) {
+						// Chain system prompt overrides
+						currentEvent = { ...currentEvent, systemPrompt: result.systemPrompt };
+						merged.systemPrompt = result.systemPrompt;
+					}
+				}
+			} catch (err) {
+				this._emitError(err instanceof Error ? err : new Error(String(err)), {
+					event: "before_agent_start",
+				});
+			}
+		}
+		return merged;
+	}
+
+	/** Emit context event. Returns modified messages if any handler modifies. */
+	async emitContext(event: ContextEvent): Promise<ContextEventResult | undefined> {
+		const handlers = this._handlers.get("context") as
+			| Array<{ handler: ExtensionHandler<ContextEvent, ContextEventResult> }>
+			| undefined;
+		if (!handlers) return undefined;
+
+		const ctx = this._buildExtensionContext();
+		let currentEvent = event;
+		let lastResult: ContextEventResult | undefined;
+		for (const { handler } of handlers) {
+			try {
+				const result = await handler(currentEvent, ctx);
+				if (result?.messages) {
+					currentEvent = { ...currentEvent, messages: result.messages };
+					lastResult = result;
+				}
+			} catch (err) {
+				this._emitError(err instanceof Error ? err : new Error(String(err)), {
+					event: "context",
+				});
+			}
+		}
+		return lastResult;
+	}
+
+	/** Emit before_provider_request. Returns last payload override. */
+	async emitBeforeProviderRequest(
+		event: BeforeProviderRequestEvent,
+	): Promise<BeforeProviderRequestEventResult> {
+		const handlers = this._handlers.get("before_provider_request") as
+			| Array<{
+					handler: ExtensionHandler<BeforeProviderRequestEvent, BeforeProviderRequestEventResult>;
+			  }>
+			| undefined;
+		if (!handlers) return event.payload;
+
+		const ctx = this._buildExtensionContext();
+		let currentEvent = event;
+		let payload = event.payload;
+		for (const { handler } of handlers) {
+			try {
+				const result = await handler(currentEvent, ctx);
+				if (result !== undefined) {
+					payload = result;
+					currentEvent = { ...currentEvent, payload };
+				}
+			} catch (err) {
+				this._emitError(err instanceof Error ? err : new Error(String(err)), {
+					event: "before_provider_request",
+				});
+			}
+		}
+		return payload;
+	}
+
+	/** Emit session_before_compact. Returns cancel/custom compaction result. */
+	async emitSessionBeforeCompact(
+		event: SessionBeforeCompactEvent,
+	): Promise<SessionBeforeCompactResult | undefined> {
+		const handlers = this._handlers.get("session_before_compact") as
+			| Array<{
+					handler: ExtensionHandler<SessionBeforeCompactEvent, SessionBeforeCompactResult>;
+			  }>
+			| undefined;
+		if (!handlers) return undefined;
+
+		const ctx = this._buildExtensionContext();
+		for (const { handler } of handlers) {
+			try {
+				const result = await handler(event, ctx);
+				if (result?.cancel || result?.compaction) return result;
+			} catch (err) {
+				this._emitError(err instanceof Error ? err : new Error(String(err)), {
+					event: "session_before_compact",
+				});
+			}
+		}
+		return undefined;
+	}
+
+	// ─── Command Execution ────────────────────────────────────────────
+
+	/** Get registered commands. */
+	getCommands(): CommandInfo[] {
+		return [...this._commands.values()].map((c) => ({
+			name: c.name,
+			description: c.options.description,
+		}));
+	}
+
+	/** Execute a registered command. Returns false if not found. */
+	async executeCommand(name: string, args: string): Promise<boolean> {
+		const command = this._commands.get(name);
+		if (!command) return false;
+
+		const ctx = this._buildExtensionCommandContext();
+		try {
+			await command.options.handler(args, ctx);
+		} catch (err) {
+			this._emitError(err instanceof Error ? err : new Error(String(err)), {
+				event: `command:${name}`,
+			});
+		}
+		return true;
+	}
+
+	// ─── Internal ─────────────────────────────────────────────────────
+
+	private _requireActions(): ExtensionRunnerActions {
+		if (!this._actions) {
+			throw new Error("ExtensionRunner: actions not bound. Call bindActions() first.");
+		}
+		return this._actions;
+	}
+
+	private _registerHandler(event: string, handler: ExtensionHandler<unknown, unknown>): void {
+		let list = this._handlers.get(event);
+		if (!list) {
+			list = [];
+			this._handlers.set(event, list);
+		}
+		list.push({ handler });
+	}
+
+	private _emitError(error: Error, context: { event?: string; extension?: string }): void {
+		for (const listener of this._errorListeners) {
+			listener(error, context);
+		}
+	}
+
+	private _buildExtensionContext(): ExtensionContext {
+		const actions = this._requireActions();
+		return {
+			ui: this._uiProvider,
+			hasUI: this._uiProvider !== noOpUIProvider,
+			sessionManager: actions.getSessionManager(),
+			model: actions.getModel(),
+			isIdle: actions.isIdle,
+			signal: actions.getSignal(),
+			abort: actions.abort,
+			hasPendingMessages: actions.hasPendingMessages,
+			shutdown: actions.shutdown,
+			getContextUsage: actions.getContextUsage,
+			compact: actions.compact,
+			getSystemPrompt: actions.getSystemPrompt,
+		};
+	}
+
+	private _buildExtensionCommandContext(): ExtensionCommandContext {
+		const actions = this._requireActions();
+		return {
+			...this._buildExtensionContext(),
+			waitForIdle: actions.waitForIdle,
+			reload: actions.reload,
+		};
+	}
+
+	private _createExtensionsAPI(): ExtensionsAPI {
+		const runner = this;
+		const actions = () => runner._requireActions();
+
+		const api: ExtensionsAPI = {
+			// biome-ignore lint/suspicious/noExplicitAny: overloaded on() signatures need a broad implementation
+			on(event: ExtensionEventName, handler: ExtensionHandler<any, any>): void {
+				runner._registerHandler(event, handler);
+			},
+
+			registerTool(tool: ToolDefinition): void {
+				actions().registerTool(tool);
+			},
+
+			getActiveTools(): string[] {
+				return actions().getActiveToolNames();
+			},
+
+			getAllTools(): ToolInfo[] {
+				return actions()
+					.getAllToolDefinitions()
+					.map((d) => ({
+						name: d.name,
+						description: d.description,
+						parameters: d.parameters,
+					}));
+			},
+
+			setActiveTools(toolNames: string[]): void {
+				actions().setActiveToolsByName(toolNames);
+			},
+
+			registerCommand(name: string, options: CommandOptions): void {
+				runner._commands.set(name, { name, options });
+			},
+
+			getCommands(): CommandInfo[] {
+				return runner.getCommands();
+			},
+
+			registerProvider(name: string, config: ProviderConfig): void {
+				runner._modelRegistry?.registerProvider(name, config);
+			},
+
+			unregisterProvider(name: string): void {
+				runner._modelRegistry?.unregisterProvider(name);
+			},
+
+			async setModel(model: Model<Api>): Promise<boolean> {
+				return actions().setModel(model);
+			},
+
+			getThinkingLevel(): ThinkingLevel {
+				return actions().getThinkingLevel();
+			},
+
+			setThinkingLevel(level: ThinkingLevel): void {
+				actions().setThinkingLevel(level);
+			},
+
+			sendMessage(message, options) {
+				actions().sendMessage(message, options);
+			},
+
+			sendUserMessage(content, options) {
+				actions().sendUserMessage(content, options);
+			},
+
+			appendEntry(customType: string, data?: unknown): void {
+				actions().appendEntry(customType, data);
+			},
+
+			setLabel(entryId: EntryId, label: string | undefined): void {
+				actions().setLabel(entryId, label);
+			},
+
+			events: runner._eventBus,
+		};
+
+		return api;
+	}
+}

--- a/packages/otter-agent/src/extensions/index.ts
+++ b/packages/otter-agent/src/extensions/index.ts
@@ -6,6 +6,7 @@ export type {
 	ExtensionContext,
 } from "./context.js";
 export type { EventBus } from "./event-bus.js";
+export { createEventBus } from "./event-bus-impl.js";
 export type {
 	AgentEndEvent,
 	AgentStartEvent,
@@ -39,5 +40,7 @@ export type {
 	TurnStartEvent,
 } from "./events.js";
 export type { Extension } from "./extension.js";
+export { ExtensionRunner } from "./extension-runner.js";
+export type { ExtensionRunnerActions } from "./extension-runner.js";
 export type { ExtensionHandler, ExtensionsAPI, ToolInfo } from "./extensions-api.js";
 export type { ProviderConfig, ProviderModelConfig } from "./providers.js";

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -8,6 +8,7 @@ export type {
 	ToolDefinition,
 	UIProvider,
 } from "./interfaces/index.js";
+export { noOpUIProvider } from "./interfaces/ui.js";
 
 // ExtensionsAPI
 export type {
@@ -30,6 +31,7 @@ export type {
 	ExtensionEvent,
 	ExtensionEventName,
 	ExtensionHandler,
+	ExtensionRunnerActions,
 	ExtensionsAPI,
 	InputEvent,
 	InputEventResult,
@@ -55,6 +57,7 @@ export type {
 	TurnEndEvent,
 	TurnStartEvent,
 } from "./extensions/index.js";
+export { createEventBus, ExtensionRunner } from "./extensions/index.js";
 
 // AgentSession
 export {
@@ -62,6 +65,7 @@ export {
 	convertToLlm,
 	createCompactionSummaryMessage,
 	createCustomMessage,
+	ModelRegistry,
 	wrapToolDefinition,
 } from "./session/index.js";
 export type {

--- a/packages/otter-agent/src/interfaces/ui.ts
+++ b/packages/otter-agent/src/interfaces/ui.ts
@@ -1,0 +1,15 @@
+/**
+ * UIProvider stub for when no real UI is available.
+ *
+ * Returns sensible defaults: false for confirm, undefined for input/select,
+ * no-op for dialog and notify.
+ */
+import type { UIProvider } from "./ui-provider.js";
+
+export const noOpUIProvider: UIProvider = {
+	dialog: async () => {},
+	confirm: async () => false,
+	input: async () => undefined,
+	select: async () => undefined,
+	notify: () => {},
+};

--- a/packages/otter-agent/src/session/agent-session.test.ts
+++ b/packages/otter-agent/src/session/agent-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { Type } from "@sinclair/typebox";
+import type { Extension } from "../extensions/extension.js";
 import type { AgentEnvironment } from "../interfaces/agent-environment.js";
 import type { AuthStorage } from "../interfaces/auth-storage.js";
 import type { SessionManager } from "../interfaces/session-manager.js";
@@ -58,7 +59,7 @@ function createTestTool(name: string): ToolDefinition {
 // ─── Tests ────────────────────────────────────────────────────────────
 
 describe("AgentSession", () => {
-	test("constructs with minimal options", () => {
+	test("constructs with minimal options", async () => {
 		const session = new AgentSession({
 			sessionManager: createMockSessionManager(),
 			authStorage: createMockAuthStorage(),
@@ -70,10 +71,10 @@ describe("AgentSession", () => {
 		expect(session.sessionManager).toBeDefined();
 		expect(session.agent.state.systemPrompt).toBe("You are a helpful assistant.");
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("appends environment system message", () => {
+	test("appends environment system message", async () => {
 		const session = new AgentSession({
 			sessionManager: createMockSessionManager(),
 			authStorage: createMockAuthStorage(),
@@ -86,10 +87,10 @@ describe("AgentSession", () => {
 		expect(session.agent.state.systemPrompt).toContain("Base prompt.");
 		expect(session.agent.state.systemPrompt).toContain("You are in a Docker container.");
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("registers environment tools", () => {
+	test("registers environment tools", async () => {
 		const tool = createTestTool("env_tool");
 		const session = new AgentSession({
 			sessionManager: createMockSessionManager(),
@@ -102,10 +103,10 @@ describe("AgentSession", () => {
 		expect(session.agent.state.tools).toHaveLength(1);
 		expect(session.agent.state.tools[0].name).toBe("env_tool");
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("includes tool snippets and guidelines in system prompt", () => {
+	test("includes tool snippets and guidelines in system prompt", async () => {
 		const tool = createTestTool("my_tool");
 		const session = new AgentSession({
 			sessionManager: createMockSessionManager(),
@@ -120,10 +121,10 @@ describe("AgentSession", () => {
 		expect(prompt).toContain("# Guidelines");
 		expect(prompt).toContain("Use my_tool for testing");
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("registerTool adds a tool and updates the agent", () => {
+	test("registerTool adds a tool and updates the agent", async () => {
 		const session = new AgentSession({
 			sessionManager: createMockSessionManager(),
 			authStorage: createMockAuthStorage(),
@@ -140,10 +141,10 @@ describe("AgentSession", () => {
 		expect(session.agent.state.tools).toHaveLength(1);
 		expect(session.agent.state.systemPrompt).toContain("new_tool");
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("setActiveToolsByName filters to valid tools", () => {
+	test("setActiveToolsByName filters to valid tools", async () => {
 		const tool1 = createTestTool("tool_a");
 		const tool2 = createTestTool("tool_b");
 		const session = new AgentSession({
@@ -160,10 +161,10 @@ describe("AgentSession", () => {
 		expect(session.getActiveToolNames()).toEqual(["tool_a"]);
 		expect(session.agent.state.tools).toHaveLength(1);
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("setModel persists to session manager", () => {
+	test("setModel persists to session manager", async () => {
 		const sm = createMockSessionManager();
 		const session = new AgentSession({
 			sessionManager: sm,
@@ -175,17 +176,36 @@ describe("AgentSession", () => {
 		const testModel = { id: "test-model", provider: "test" } as Parameters<
 			typeof session.setModel
 		>[0];
-		session.setModel(testModel);
+		const result = await session.setModel(testModel);
 
+		expect(result).toBe(true);
 		expect(sm.appendModelChange).toHaveBeenCalledWith(
 			{ provider: "test", modelId: "test-model" },
 			"off",
 		);
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("setThinkingLevel persists to session manager", () => {
+	test("setModel returns false when no auth available", async () => {
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: { getApiKey: async () => undefined },
+			environment: createMockEnvironment(),
+			systemPrompt: "Prompt.",
+		});
+
+		const testModel = { id: "test-model", provider: "no-auth-provider" } as Parameters<
+			typeof session.setModel
+		>[0];
+		const result = await session.setModel(testModel);
+
+		expect(result).toBe(false);
+
+		await session.dispose();
+	});
+
+	test("setThinkingLevel persists to session manager", async () => {
 		const sm = createMockSessionManager();
 		const session = new AgentSession({
 			sessionManager: sm,
@@ -198,10 +218,10 @@ describe("AgentSession", () => {
 
 		expect(sm.appendThinkingLevelChange).toHaveBeenCalledWith("high");
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("subscribe and dispose work correctly", () => {
+	test("subscribe and dispose work correctly", async () => {
 		const session = new AgentSession({
 			sessionManager: createMockSessionManager(),
 			authStorage: createMockAuthStorage(),
@@ -224,10 +244,10 @@ describe("AgentSession", () => {
 		session.compact();
 		expect(events).toHaveLength(0);
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("agent events are forwarded to session subscribers", () => {
+	test("authStorage is wired via ModelRegistry as the agent's API key resolver", async () => {
 		const session = new AgentSession({
 			sessionManager: createMockSessionManager(),
 			authStorage: createMockAuthStorage(),
@@ -235,39 +255,13 @@ describe("AgentSession", () => {
 			systemPrompt: "Prompt.",
 		});
 
-		const events: string[] = [];
-		session.subscribe((e) => events.push(e.type));
-
-		// Simulate an agent event by subscribing to the agent and
-		// verifying the session forwards it. We can trigger agent_start/agent_end
-		// via the agent's internal emit by calling prompt with no model set
-		// (it will error, but events should still fire).
-		// Instead, let's verify the wiring exists: the session subscribes to agent
-		// events, so any agent event should appear in our session subscriber.
-		// We verify this via the compact() method which emits session-level events.
-		// Agent-level events require an actual agent loop (needs LLM), so we
-		// can only verify the subscription wiring exists.
-		expect(session.agent).toBeDefined();
-
-		session.dispose();
-	});
-
-	test("authStorage is wired as the agent's API key resolver", () => {
-		const authStorage = createMockAuthStorage();
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage,
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
-
-		// The agent's getApiKey should delegate to authStorage
 		expect(session.agent.getApiKey).toBeDefined();
+		expect(session.modelRegistry).toBeDefined();
 
-		session.dispose();
+		await session.dispose();
 	});
 
-	test("getAllToolDefinitions returns all registered tools", () => {
+	test("getAllToolDefinitions returns all registered tools", async () => {
 		const tool1 = createTestTool("tool_x");
 		const tool2 = createTestTool("tool_y");
 		const session = new AgentSession({
@@ -283,6 +277,173 @@ describe("AgentSession", () => {
 		expect(defs).toHaveLength(2);
 		expect(defs.map((d) => d.name).sort()).toEqual(["tool_x", "tool_y"]);
 
-		session.dispose();
+		await session.dispose();
+	});
+
+	test("getSystemPrompt returns the current system prompt", async () => {
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "My prompt.",
+		});
+
+		expect(session.getSystemPrompt()).toBe("My prompt.");
+
+		await session.dispose();
+	});
+
+	// ─── Extension Integration ────────────────────────────────────────
+
+	describe("extension integration", () => {
+		test("loadExtensions fires session_start event", async () => {
+			const handler = mock(() => {});
+			const ext: Extension = (api) => api.on("session_start", handler);
+
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: createMockEnvironment(),
+				systemPrompt: "Prompt.",
+			});
+
+			await session.loadExtensions([ext]);
+
+			expect(handler).toHaveBeenCalledTimes(1);
+
+			await session.dispose();
+		});
+
+		test("dispose fires session_shutdown event", async () => {
+			const handler = mock(() => {});
+			const ext: Extension = (api) => api.on("session_shutdown", handler);
+
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: createMockEnvironment(),
+				systemPrompt: "Prompt.",
+			});
+
+			await session.loadExtensions([ext]);
+			await session.dispose();
+
+			expect(handler).toHaveBeenCalledTimes(1);
+		});
+
+		test("extension can register a tool via api.registerTool", async () => {
+			const tool = createTestTool("ext_registered_tool");
+			const ext: Extension = (api) => api.registerTool(tool);
+
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: createMockEnvironment(),
+				systemPrompt: "Prompt.",
+			});
+
+			await session.loadExtensions([ext]);
+
+			expect(session.getActiveToolNames()).toContain("ext_registered_tool");
+			expect(session.agent.state.tools.map((t) => t.name)).toContain("ext_registered_tool");
+
+			await session.dispose();
+		});
+
+		test("extension can register a command and it can be executed", async () => {
+			const handler = mock(async () => {});
+			const ext: Extension = (api) =>
+				api.registerCommand("test-cmd", {
+					description: "A test command",
+					handler,
+				});
+
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: createMockEnvironment(),
+				systemPrompt: "Prompt.",
+			});
+
+			await session.loadExtensions([ext]);
+
+			const commands = session.extensionRunner.getCommands();
+			expect(commands).toHaveLength(1);
+			expect(commands[0].name).toBe("test-cmd");
+
+			const result = await session.extensionRunner.executeCommand("test-cmd", "args");
+			expect(result).toBe(true);
+			expect(handler).toHaveBeenCalledTimes(1);
+
+			await session.dispose();
+		});
+
+		test("reload clears and reloads extensions", async () => {
+			const startHandler = mock(() => {});
+			const ext: Extension = (api) => api.on("session_start", startHandler);
+
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: createMockEnvironment(),
+				systemPrompt: "Prompt.",
+			});
+
+			await session.loadExtensions([ext]);
+			expect(startHandler).toHaveBeenCalledTimes(1);
+
+			await session.reload();
+			// session_start fires again after reload
+			expect(startHandler).toHaveBeenCalledTimes(2);
+
+			await session.dispose();
+		});
+
+		test("extensions passed via options are loaded by loadExtensions", async () => {
+			const handler = mock(() => {});
+			const ext: Extension = (api) => api.on("session_start", handler);
+
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: createMockEnvironment(),
+				systemPrompt: "Prompt.",
+				extensions: [ext],
+			});
+
+			await session.loadExtensions();
+
+			expect(handler).toHaveBeenCalledTimes(1);
+
+			await session.dispose();
+		});
+
+		test("extensionRunner is accessible", async () => {
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: createMockEnvironment(),
+				systemPrompt: "Prompt.",
+			});
+
+			expect(session.extensionRunner).toBeDefined();
+			expect(session.extensionRunner.getCommands()).toHaveLength(0);
+
+			await session.dispose();
+		});
+
+		test("modelRegistry is accessible and has built-in models", async () => {
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: createMockEnvironment(),
+				systemPrompt: "Prompt.",
+			});
+
+			expect(session.modelRegistry).toBeDefined();
+			expect(session.modelRegistry.getAll().length).toBeGreaterThan(0);
+
+			await session.dispose();
+		});
 	});
 });

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -11,12 +11,17 @@ import type {
 	ThinkingLevel,
 } from "@mariozechner/pi-agent-core";
 import type { Api, ImageContent, Model } from "@mariozechner/pi-ai";
+import type { CompactOptions } from "../extensions/context.js";
+import { ExtensionRunner } from "../extensions/extension-runner.js";
+import type { ExtensionRunnerActions } from "../extensions/extension-runner.js";
+import type { Extension } from "../extensions/extension.js";
 import type { AgentEnvironment } from "../interfaces/agent-environment.js";
 import type { AuthStorage } from "../interfaces/auth-storage.js";
-import type { SessionManager } from "../interfaces/session-manager.js";
+import type { EntryId, SessionManager } from "../interfaces/session-manager.js";
 import type { ToolDefinition } from "../interfaces/tool-definition.js";
 import type { UIProvider } from "../interfaces/ui-provider.js";
 import { convertToLlm } from "./messages.js";
+import { ModelRegistry } from "./model-registry.js";
 import { wrapToolDefinition } from "./tool-wrapper.js";
 
 /** Options for creating an AgentSession. */
@@ -41,6 +46,9 @@ export interface AgentSessionOptions {
 
 	/** Optional UI provider for extension interaction. */
 	uiProvider?: UIProvider;
+
+	/** Extensions to load. */
+	extensions?: Extension[];
 
 	/** Additional pi-agent-core Agent options. */
 	agentOptions?: Partial<AgentOptions>;
@@ -71,12 +79,17 @@ export class AgentSession {
 	/** Optional UI provider for extensions. */
 	readonly uiProvider: UIProvider | undefined;
 
+	/** Model registry for provider management. */
+	readonly modelRegistry: ModelRegistry;
+
 	private readonly _authStorage: AuthStorage;
 	private readonly _environment: AgentEnvironment;
 	private readonly _baseSystemPrompt: string;
 	private readonly _environmentAppend: string | undefined;
 	private readonly _eventListeners: Set<AgentSessionEventListener> = new Set();
+	private readonly _extensionRunner: ExtensionRunner;
 	private _unsubscribeAgent: () => void;
+	private _extensions: Extension[];
 
 	// Tool management
 	private readonly _toolRegistry: Map<string, AgentTool> = new Map();
@@ -89,6 +102,17 @@ export class AgentSession {
 		this._environment = options.environment;
 		this._baseSystemPrompt = options.systemPrompt;
 		this.uiProvider = options.uiProvider;
+		this._extensions = options.extensions ?? [];
+
+		// Create model registry
+		this.modelRegistry = new ModelRegistry(this._authStorage);
+
+		// Create extension runner
+		this._extensionRunner = new ExtensionRunner();
+		if (options.uiProvider) {
+			this._extensionRunner.setUIProvider(options.uiProvider);
+		}
+		this._extensionRunner.setModelRegistry(this.modelRegistry);
 
 		// Resolve environment at startup (called once)
 		this._environmentAppend = this._environment.getSystemMessageAppend();
@@ -118,14 +142,45 @@ export class AgentSession {
 				...options.agentOptions?.initialState,
 			},
 			convertToLlm: options.agentOptions?.convertToLlm ?? convertToLlm,
-			getApiKey: (provider) => this._authStorage.getApiKey(provider),
+			getApiKey: (provider) => this.modelRegistry.getApiKey(provider),
 		});
 
 		// Install tool hooks for extension events
 		this._installToolHooks();
 
+		// Bind extension runner actions
+		this._extensionRunner.bindActions(this._buildRunnerActions());
+
 		// Subscribe to agent events for persistence and forwarding
 		this._unsubscribeAgent = this.agent.subscribe(this._handleAgentEvent);
+	}
+
+	// ─── Extension Loading ────────────────────────────────────────────
+
+	/**
+	 * Load extensions and fire session_start.
+	 * Call this after construction to initialise extensions.
+	 */
+	async loadExtensions(extensions?: Extension[]): Promise<void> {
+		if (extensions) {
+			this._extensions = extensions;
+		}
+		await this._extensionRunner.loadExtensions(this._extensions);
+		await this._extensionRunner.emit({ type: "session_start" });
+	}
+
+	/** Get the extension runner for direct access (commands, error listeners, etc). */
+	get extensionRunner(): ExtensionRunner {
+		return this._extensionRunner;
+	}
+
+	/**
+	 * Reload extensions: clears all handlers, reloads, fires session_start.
+	 */
+	async reload(): Promise<void> {
+		this._extensionRunner.clear();
+		await this._extensionRunner.loadExtensions(this._extensions);
+		await this._extensionRunner.emit({ type: "session_start" });
 	}
 
 	// ─── Core Interaction ─────────────────────────────────────────────
@@ -157,13 +212,16 @@ export class AgentSession {
 
 	// ─── Model Control ────────────────────────────────────────────────
 
-	/** Set the current model. */
-	setModel(model: Model<Api>): void {
+	/** Set the current model. Returns false if no API key is available. */
+	async setModel(model: Model<Api>): Promise<boolean> {
+		const hasAuth = await this.modelRegistry.hasAuth(model);
+		if (!hasAuth) return false;
 		this.agent.setModel(model);
 		this.sessionManager.appendModelChange(
 			{ provider: model.provider, modelId: model.id },
 			this.agent.state.thinkingLevel,
 		);
+		return true;
 	}
 
 	/** Set the thinking level. */
@@ -208,6 +266,13 @@ export class AgentSession {
 		};
 	}
 
+	// ─── System Prompt ────────────────────────────────────────────────
+
+	/** Get the current effective system prompt. */
+	getSystemPrompt(): string {
+		return this.agent.state.systemPrompt;
+	}
+
 	// ─── Compaction ───────────────────────────────────────────────────
 
 	/** Compact the conversation context. */
@@ -221,7 +286,8 @@ export class AgentSession {
 	// ─── Cleanup ──────────────────────────────────────────────────────
 
 	/** Unsubscribe from the underlying Agent and clean up. */
-	dispose(): void {
+	async dispose(): Promise<void> {
+		await this._extensionRunner.emit({ type: "session_shutdown" });
 		this._unsubscribeAgent();
 		this._eventListeners.clear();
 	}
@@ -240,27 +306,139 @@ export class AgentSession {
 			this.sessionManager.appendMessage(event.message);
 		}
 
+		// Forward agent events to extension handlers
+		this._extensionRunner.emit(event).catch(() => {
+			// Errors are handled by extension runner error listeners
+		});
+
 		// Forward to session-level listeners
 		this._emit(event);
 	};
 
 	/**
 	 * Install beforeToolCall/afterToolCall hooks on the Agent.
-	 *
-	 * These hooks will be the integration point for extension tool_call
-	 * and tool_result events (wired up in #4 extension loading).
-	 * For now they are placeholders that can be extended.
+	 * These hooks dispatch tool_call and tool_result events to extensions.
 	 */
 	private _installToolHooks(): void {
-		this.agent.setBeforeToolCall(async (_context) => {
-			// Extension tool_call event dispatch will be wired here in #4
+		this.agent.setBeforeToolCall(async (context) => {
+			if (!this._extensionRunner.hasHandlers("tool_call")) return undefined;
+
+			const result = await this._extensionRunner.emitToolCall({
+				type: "tool_call",
+				toolCallId: context.toolCall.id,
+				toolName: context.toolCall.name,
+				input: (context.args as Record<string, unknown>) ?? {},
+			});
+
+			if (result?.block) {
+				return { block: true, reason: result.reason };
+			}
 			return undefined;
 		});
 
-		this.agent.setAfterToolCall(async (_context) => {
-			// Extension tool_result event dispatch will be wired here in #4
+		this.agent.setAfterToolCall(async (context) => {
+			if (!this._extensionRunner.hasHandlers("tool_result")) return undefined;
+
+			const result = await this._extensionRunner.emitToolResult({
+				type: "tool_result",
+				toolCallId: context.toolCall.id,
+				toolName: context.toolCall.name,
+				input: (context.args as Record<string, unknown>) ?? {},
+				content: context.result.content,
+				details: context.result.details,
+				isError: context.isError,
+			});
+
+			if (result) {
+				return {
+					content: result.content,
+					details: result.details,
+					isError: result.isError,
+				};
+			}
 			return undefined;
 		});
+	}
+
+	/** Build runner actions that delegate to this session. */
+	private _buildRunnerActions(): ExtensionRunnerActions {
+		return {
+			registerTool: (tool) => this.registerTool(tool),
+			getActiveToolNames: () => this.getActiveToolNames(),
+			getAllToolDefinitions: () => this.getAllToolDefinitions(),
+			setActiveToolsByName: (names) => this.setActiveToolsByName(names),
+			setModel: (model) => this.setModel(model),
+			getThinkingLevel: () => this.agent.state.thinkingLevel,
+			setThinkingLevel: (level) => this.setThinkingLevel(level),
+			sendMessage: (message, options) => {
+				// Convert custom message to AgentMessage and deliver
+				const agentMessage = {
+					role: "custom" as const,
+					customType: message.customType,
+					content: message.content,
+					display: message.display,
+					details: message.details,
+					timestamp: Date.now(),
+				};
+				this.sessionManager.appendCustomMessageEntry(
+					message.customType,
+					message.content,
+					message.display,
+				);
+				if (options?.deliverAs === "steer") {
+					this.agent.steer(agentMessage as AgentMessage);
+				} else if (options?.deliverAs === "followUp" || options?.triggerTurn) {
+					this.agent.followUp(agentMessage as AgentMessage);
+				} else {
+					this.agent.appendMessage(agentMessage as AgentMessage);
+				}
+			},
+			sendUserMessage: (content, options) => {
+				const text = typeof content === "string" ? content : JSON.stringify(content);
+				const userMessage = {
+					role: "user" as const,
+					content: text,
+					timestamp: Date.now(),
+				} as AgentMessage;
+				if (options?.deliverAs === "steer") {
+					this.agent.steer(userMessage);
+				} else {
+					this.agent.followUp(userMessage);
+				}
+			},
+			appendEntry: (customType, data) => {
+				this.sessionManager.appendCustomEntry(customType, data);
+			},
+			setLabel: (entryId: EntryId, label: string | undefined) => {
+				if (label !== undefined) {
+					this.sessionManager.appendLabel(label, entryId);
+				}
+			},
+			getSessionManager: () => this.sessionManager,
+			getModel: () => this.agent.state.model,
+			isIdle: () => !this.agent.state.isStreaming,
+			getSignal: () => this.agent.signal,
+			abort: () => this.abort(),
+			hasPendingMessages: () => this.agent.hasQueuedMessages(),
+			shutdown: () => {
+				this.dispose();
+			},
+			getContextUsage: () => {
+				const model = this.agent.state.model;
+				if (!model) return undefined;
+				return {
+					tokens: null,
+					contextWindow: model.contextWindow ?? 0,
+					percent: null,
+				};
+			},
+			compact: (options?: CompactOptions) => {
+				this.compact(options?.customInstructions);
+			},
+			getSystemPrompt: () => this.getSystemPrompt(),
+			waitForIdle: () => this.waitForIdle(),
+			reload: () => this.reload(),
+		};
 	}
 
 	/** Build the full system prompt from base + environment + tools. */

--- a/packages/otter-agent/src/session/index.ts
+++ b/packages/otter-agent/src/session/index.ts
@@ -2,4 +2,5 @@ export { AgentSession } from "./agent-session.js";
 export type { AgentSessionEvent, AgentSessionOptions } from "./agent-session.js";
 export { convertToLlm, createCompactionSummaryMessage, createCustomMessage } from "./messages.js";
 export type { CompactionSummaryMessage, CustomMessage } from "./messages.js";
+export { ModelRegistry } from "./model-registry.js";
 export { wrapToolDefinition } from "./tool-wrapper.js";

--- a/packages/otter-agent/src/session/model-registry.test.ts
+++ b/packages/otter-agent/src/session/model-registry.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ProviderConfig, ProviderModelConfig } from "../extensions/providers.js";
+import type { AuthStorage } from "../interfaces/auth-storage.js";
+import { ModelRegistry } from "./model-registry.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function createMockAuthStorage(overrides?: Partial<AuthStorage>): AuthStorage {
+	return {
+		getApiKey: mock(async (provider: string) => {
+			if (provider === "openai") return "sk-test-openai";
+			if (provider === "anthropic") return "sk-test-anthropic";
+			return undefined;
+		}),
+		...overrides,
+	};
+}
+
+/** A minimal extension-registered model config. */
+function extModel(
+	id: string,
+	name: string,
+	overrides?: Partial<ProviderModelConfig>,
+): ProviderModelConfig {
+	return {
+		id,
+		name,
+		api: "anthropic-messages",
+		...overrides,
+	};
+}
+
+/** A minimal provider config with models. */
+function providerConfig(
+	models: ProviderModelConfig[] = [],
+	overrides?: Partial<ProviderConfig>,
+): ProviderConfig {
+	return {
+		models,
+		...overrides,
+	};
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("ModelRegistry", () => {
+	test("constructor loads built-in models from pi-ai", () => {
+		const registry = new ModelRegistry(createMockAuthStorage());
+		const all = registry.getAll();
+
+		// pi-ai should have at least some built-in providers
+		expect(all.length).toBeGreaterThan(0);
+
+		// All models should have provider and id
+		for (const model of all) {
+			expect(model.provider).toBeDefined();
+			expect(model.id).toBeDefined();
+		}
+	});
+
+	test("find returns a model by provider and ID", () => {
+		const registry = new ModelRegistry(createMockAuthStorage());
+		const all = registry.getAll();
+		if (all.length === 0) return;
+
+		const first = all[0];
+		const found = registry.find(first.provider, first.id);
+		expect(found).toBeDefined();
+		expect(found?.id).toBe(first.id);
+	});
+
+	test("find returns undefined for unknown model", () => {
+		const registry = new ModelRegistry(createMockAuthStorage());
+		expect(registry.find("nonexistent", "nope")).toBeUndefined();
+	});
+
+	// ─── API Key Resolution ──────────────────────────────────────
+
+	describe("getApiKey", () => {
+		test("falls back to AuthStorage when no extension provider is registered", async () => {
+			const authStorage = createMockAuthStorage();
+			const registry = new ModelRegistry(authStorage);
+
+			const key = await registry.getApiKey("openai");
+			expect(key).toBe("sk-test-openai");
+			expect(authStorage.getApiKey).toHaveBeenCalledWith("openai");
+		});
+
+		test("returns extension provider apiKey directly", async () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+			registry.registerProvider("custom", providerConfig([], { apiKey: "custom-key-123" }));
+
+			const key = await registry.getApiKey("custom");
+			expect(key).toBe("custom-key-123");
+		});
+
+		test("resolves env var names from process.env", async () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+			registry.registerProvider("envprovider", providerConfig([], { apiKey: "MY_CUSTOM_KEY" }));
+
+			process.env.MY_CUSTOM_KEY = "resolved-value";
+			try {
+				const key = await registry.getApiKey("envprovider");
+				expect(key).toBe("resolved-value");
+			} finally {
+				process.env.MY_CUSTOM_KEY = undefined;
+			}
+		});
+
+		test("returns raw apiKey when it does not look like an env var", async () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+			registry.registerProvider("raw", providerConfig([], { apiKey: "not-an-env-var" }));
+
+			const key = await registry.getApiKey("raw");
+			expect(key).toBe("not-an-env-var");
+		});
+
+		test("env var name not set in environment returns the raw apiKey string", async () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+			registry.registerProvider(
+				"missingenv",
+				providerConfig([], { apiKey: "TOTALLY_MISSING_KEY" }),
+			);
+
+			const key = await registry.getApiKey("missingenv");
+			// "TOTALLY_MISSING_KEY" looks like an env var but isn't set,
+			// so the implementation falls through and returns the raw string.
+			expect(key).toBe("TOTALLY_MISSING_KEY");
+		});
+	});
+
+	// ─── hasAuth ─────────────────────────────────────────────────
+
+	describe("hasAuth", () => {
+		test("returns true when API key is available", async () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+			const model = registry.find("openai", "gpt-4o");
+			if (!model) return; // skip if no built-in openai model
+
+			expect(await registry.hasAuth(model)).toBe(true);
+		});
+
+		test("returns false when no API key is available", async () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+			// Create a fake model for a provider with no auth
+			const fakeModel = {
+				id: "fake",
+				name: "Fake",
+				api: "openai-chat",
+				provider: "noauth-provider",
+				baseUrl: "",
+			} as Model<Api>;
+
+			expect(await registry.hasAuth(fakeModel)).toBe(false);
+		});
+	});
+
+	// ─── Provider Registration ───────────────────────────────────
+
+	describe("registerProvider with models", () => {
+		test("replaces existing models for the provider", () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+
+			// Get count of built-in models for "openai"
+			const openaiBefore = registry.getAll().filter((m) => m.provider === "openai");
+
+			registry.registerProvider("openai", providerConfig([extModel("custom-gpt", "Custom GPT")]));
+
+			const openaiAfter = registry.getAll().filter((m) => m.provider === "openai");
+			expect(openaiAfter).toHaveLength(1);
+			expect(openaiAfter[0].id).toBe("custom-gpt");
+			// Built-in count should be restorable (not lost)
+			expect(openaiBefore.length).toBeGreaterThan(0);
+		});
+
+		test("adds models for a new provider", () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+
+			registry.registerProvider(
+				"myprovider",
+				providerConfig([extModel("model-a", "Model A"), extModel("model-b", "Model B")]),
+			);
+
+			expect(registry.find("myprovider", "model-a")).toBeDefined();
+			expect(registry.find("myprovider", "model-b")).toBeDefined();
+		});
+	});
+
+	describe("registerProvider with only baseUrl", () => {
+		test("overrides baseUrl on existing models", () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+
+			// Find a provider that has at least one model
+			const all = registry.getAll();
+			const existing = all.find((m) => m.provider === "openai" || m.provider === "anthropic");
+			if (!existing) return; // skip if no known provider models
+
+			const originalUrl = existing.baseUrl;
+
+			registry.registerProvider(existing.provider, {
+				baseUrl: "https://custom.example.com/v1",
+			} as ProviderConfig);
+
+			const updated = registry.find(existing.provider, existing.id);
+			expect(updated).toBeDefined();
+			expect(updated?.baseUrl).toBe("https://custom.example.com/v1");
+			expect(updated?.baseUrl).not.toBe(originalUrl);
+		});
+	});
+
+	// ─── Provider Unregistration ─────────────────────────────────
+
+	describe("unregisterProvider", () => {
+		test("removes extension models and restores built-in models", () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+
+			const openaiBefore = registry.getAll().filter((m) => m.provider === "openai");
+			if (openaiBefore.length === 0) return;
+
+			// Register extension models
+			registry.registerProvider(
+				"openai",
+				providerConfig([extModel("ext-model", "Extension Model")]),
+			);
+
+			expect(registry.getAll().filter((m) => m.provider === "openai")).toHaveLength(1);
+			expect(registry.find("openai", "ext-model")).toBeDefined();
+
+			// Unregister
+			registry.unregisterProvider("openai");
+
+			const openaiAfter = registry.getAll().filter((m) => m.provider === "openai");
+			expect(openaiAfter.map((m) => m.id).sort()).toEqual(openaiBefore.map((m) => m.id).sort());
+		});
+
+		test("unregistering a non-registered provider is a no-op", () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+			const countBefore = registry.getAll().length;
+
+			registry.unregisterProvider("never-registered");
+
+			expect(registry.getAll().length).toBe(countBefore);
+		});
+	});
+
+	// ─── Model creation ──────────────────────────────────────────
+
+	describe("model creation", () => {
+		test("extension model inherits provider config fields", () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+
+			registry.registerProvider(
+				"myprovider",
+				providerConfig([extModel("m1", "M1", { contextWindow: 4096, maxTokens: 1024 })], {
+					baseUrl: "https://api.example.com",
+					headers: { "X-Custom": "value" },
+				}),
+			);
+
+			const model = registry.find("myprovider", "m1");
+			expect(model).toBeDefined();
+			expect(model?.baseUrl).toBe("https://api.example.com");
+			expect(model?.contextWindow).toBe(4096);
+			expect(model?.maxTokens).toBe(1024);
+			expect((model?.headers as Record<string, string>)["X-Custom"]).toBe("value");
+		});
+
+		test("model-level headers override provider-level headers", () => {
+			const registry = new ModelRegistry(createMockAuthStorage());
+
+			registry.registerProvider(
+				"myprovider",
+				providerConfig([extModel("m1", "M1", { headers: { "X-Model": "override" } })], {
+					baseUrl: "https://api.example.com",
+					headers: { "X-Model": "provider-level", "X-Common": "yes" },
+				}),
+			);
+
+			const model = registry.find("myprovider", "m1");
+			expect(model).toBeDefined();
+			expect((model?.headers as Record<string, string>)["X-Model"]).toBe("override");
+			expect((model?.headers as Record<string, string>)["X-Common"]).toBe("yes");
+		});
+	});
+});

--- a/packages/otter-agent/src/session/model-registry.ts
+++ b/packages/otter-agent/src/session/model-registry.ts
@@ -1,0 +1,145 @@
+/**
+ * Model registry — manages built-in and extension-registered models,
+ * provides API key resolution via AuthStorage.
+ *
+ * Built-in models are loaded from pi-ai at construction. Extensions
+ * can register additional providers/models dynamically.
+ */
+import { type Api, type Model, getModels, getProviders } from "@mariozechner/pi-ai";
+import type { ProviderConfig, ProviderModelConfig } from "../extensions/providers.js";
+import type { AuthStorage } from "../interfaces/auth-storage.js";
+
+export class ModelRegistry {
+	private readonly _authStorage: AuthStorage;
+	private _models: Map<string, Model<Api>> = new Map();
+	private _registeredProviders: Map<string, ProviderConfig> = new Map();
+	/** Snapshot of built-in models for restore on unregister. */
+	private readonly _builtInModels: Map<string, Model<Api>>;
+
+	constructor(authStorage: AuthStorage) {
+		this._authStorage = authStorage;
+		this._builtInModels = this._loadBuiltInModels();
+		this._models = new Map(this._builtInModels);
+	}
+
+	/** Get all available models. */
+	getAll(): Model<Api>[] {
+		return [...this._models.values()];
+	}
+
+	/** Find a model by provider and ID. */
+	find(provider: string, modelId: string): Model<Api> | undefined {
+		return this._models.get(this._key(provider, modelId));
+	}
+
+	/** Get API key for a provider. */
+	async getApiKey(provider: string): Promise<string | undefined> {
+		// Check extension-registered provider config first
+		const config = this._registeredProviders.get(provider);
+		if (config?.apiKey) {
+			// If it looks like an env var name (all caps, underscores), resolve it
+			if (/^[A-Z_]+$/.test(config.apiKey)) {
+				const envVal = process.env[config.apiKey];
+				if (envVal) return envVal;
+			}
+			return config.apiKey;
+		}
+		// Fall back to AuthStorage
+		return this._authStorage.getApiKey(provider);
+	}
+
+	/** Check if a model has auth configured (without refreshing tokens). */
+	async hasAuth(model: Model<Api>): Promise<boolean> {
+		const key = await this.getApiKey(model.provider);
+		return key !== undefined;
+	}
+
+	/**
+	 * Register or override a model provider.
+	 *
+	 * If `models` is provided, replaces all existing models for this provider.
+	 * If only `baseUrl` is provided, overrides the URL for existing models.
+	 */
+	registerProvider(name: string, config: ProviderConfig): void {
+		this._registeredProviders.set(name, config);
+
+		if (config.models) {
+			// Remove existing models for this provider
+			for (const [key, model] of this._models) {
+				if (model.provider === name) {
+					this._models.delete(key);
+				}
+			}
+			// Add new models
+			for (const modelConfig of config.models) {
+				const model = this._createModel(name, modelConfig, config);
+				this._models.set(this._key(name, model.id), model);
+			}
+		} else if (config.baseUrl) {
+			// Override baseUrl for existing models
+			for (const [key, model] of this._models) {
+				if (model.provider === name) {
+					this._models.set(key, { ...model, baseUrl: config.baseUrl });
+				}
+			}
+		}
+	}
+
+	/**
+	 * Unregister a previously registered provider.
+	 * Removes extension models and restores built-in models for this provider.
+	 */
+	unregisterProvider(name: string): void {
+		if (!this._registeredProviders.has(name)) return;
+		this._registeredProviders.delete(name);
+
+		// Remove all models for this provider
+		for (const [key, model] of this._models) {
+			if (model.provider === name) {
+				this._models.delete(key);
+			}
+		}
+
+		// Restore built-in models for this provider
+		for (const [key, model] of this._builtInModels) {
+			if (model.provider === name) {
+				this._models.set(key, model);
+			}
+		}
+	}
+
+	private _key(provider: string, modelId: string): string {
+		return `${provider}:${modelId}`;
+	}
+
+	private _loadBuiltInModels(): Map<string, Model<Api>> {
+		const models = new Map<string, Model<Api>>();
+		for (const provider of getProviders()) {
+			for (const model of getModels(provider)) {
+				models.set(this._key(model.provider, model.id), model as Model<Api>);
+			}
+		}
+		return models;
+	}
+
+	private _createModel(
+		providerName: string,
+		config: ProviderModelConfig,
+		providerConfig: ProviderConfig,
+	): Model<Api> {
+		return {
+			id: config.id,
+			name: config.name,
+			api: (config.api ?? providerConfig.api ?? "anthropic-messages") as Api,
+			provider: providerName,
+			baseUrl: providerConfig.baseUrl ?? "",
+			reasoning: config.reasoning,
+			input: config.input,
+			cost: config.cost,
+			contextWindow: config.contextWindow,
+			maxTokens: config.maxTokens,
+			headers: { ...providerConfig.headers, ...config.headers },
+			compat: config.compat,
+		};
+	}
+}


### PR DESCRIPTION
## Summary
- **ExtensionRunner**: loads extensions, dispatches typed events (fire-and-forget, cancellable, modifying, first-match) to handlers in registration order, manages commands, and creates scoped ExtensionsAPI instances per extension
- **ModelRegistry**: loads built-in models from pi-ai's `getProviders()`/`getModels()`, supports extension-registered providers with API key resolution (env var or direct), and restores built-in models on unregister
- **AgentSession integration**: wires ExtensionRunner with bound actions, dispatches `tool_call`/`tool_result` events through `beforeToolCall`/`afterToolCall` hooks, forwards agent events to extension handlers, fires `session_start` on load and `session_shutdown` on dispose, supports `reload()` and `loadExtensions()`
- **EventBus**: channel-based pub/sub for extension-to-extension communication with `clear()` for reload
- **noOpUIProvider**: stub for headless/test usage
- `setModel()` now async with auth check via ModelRegistry
- Updated barrel exports across all index files
- 94 tests passing (12 new integration tests for AgentSession + extensions, 37 ExtensionRunner tests, 14 ModelRegistry tests, 5 EventBus tests)

## Test plan
- [x] All 94 tests pass (`bun test`)
- [x] Build passes (`bun run build`)
- [x] Lint clean (`bun run lint`)
- [x] Extension loading (sync/async), error handling during load
- [x] Event dispatch: fire-and-forget, cancellable (tool_call, session_before_compact), modifying (tool_result, context, before_provider_request), first-match (input), chaining (before_agent_start)
- [x] Command registration and execution with error handling
- [x] ModelRegistry: built-in model loading, provider registration/unregistration, API key resolution (env var, direct, fallback to AuthStorage)
- [x] AgentSession integration: session_start/session_shutdown lifecycle, tool registration via extensions, command execution, reload
- [x] EventBus: emit/subscribe, unsubscribe, clear on reload

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)