### PR TITLE
feat: implement RPC handler with command dispatch, event forwarding, and extension UI bridge

### DIFF
--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -78,6 +78,10 @@ export type {
 	CustomMessage,
 } from "./session/index.js";
 
+// RPC handler
+export { RpcHandler, createRpcUIProvider } from "./rpc/index.js";
+export type { RpcHandlerOptions } from "./rpc/index.js";
+
 // RPC protocol
 export type {
 	AbortCommand,

--- a/packages/otter-agent/src/rpc/index.ts
+++ b/packages/otter-agent/src/rpc/index.ts
@@ -39,3 +39,7 @@ export type {
 	// Transport
 	RpcTransport,
 } from "./types.js";
+
+export { RpcHandler } from "./rpc-handler.js";
+export type { RpcHandlerOptions } from "./rpc-handler.js";
+export { createRpcUIProvider } from "./rpc-ui-provider.js";

--- a/packages/otter-agent/src/rpc/rpc-handler.test.ts
+++ b/packages/otter-agent/src/rpc/rpc-handler.test.ts
@@ -1,0 +1,586 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentEnvironment } from "../interfaces/agent-environment.js";
+import type { AuthStorage } from "../interfaces/auth-storage.js";
+import type { SessionManager } from "../interfaces/session-manager.js";
+import { AgentSession } from "../session/agent-session.js";
+import { RpcHandler } from "./rpc-handler.js";
+import type {
+	RpcAgentEvent,
+	RpcInboundMessage,
+	RpcOutboundMessage,
+	RpcResponse,
+	RpcTransport,
+} from "./types.js";
+
+// ─── Test Helpers ─────────────────────────────────────────────────────
+
+function createMockSessionManager(): SessionManager {
+	let entryCounter = 0;
+	return {
+		appendMessage: mock(() => String(++entryCounter)),
+		buildSessionContext: mock(() => []),
+		compact: mock(() => String(++entryCounter)),
+		appendCustomEntry: mock(() => String(++entryCounter)),
+		appendCustomMessageEntry: mock(() => String(++entryCounter)),
+		appendModelChange: mock(() => String(++entryCounter)),
+		appendThinkingLevelChange: mock(() => String(++entryCounter)),
+		appendLabel: mock(() => String(++entryCounter)),
+	};
+}
+
+function createMockAuthStorage(): AuthStorage {
+	return {
+		getApiKey: mock(async () => "test-api-key"),
+	};
+}
+
+function createMockEnvironment(): AgentEnvironment {
+	return {
+		getSystemMessageAppend: () => undefined,
+		getTools: () => [],
+	};
+}
+
+interface MockTransport extends RpcTransport {
+	sent: RpcOutboundMessage[];
+	messageHandler: ((message: RpcInboundMessage) => void) | undefined;
+	inject(message: RpcInboundMessage): void;
+}
+
+function createMockTransport(): MockTransport {
+	const transport: MockTransport = {
+		sent: [],
+		messageHandler: undefined,
+		onMessage(handler) {
+			transport.messageHandler = handler;
+		},
+		send(message) {
+			transport.sent.push(message);
+		},
+		close: mock(() => {}),
+		inject(message) {
+			transport.messageHandler?.(message);
+		},
+	};
+	return transport;
+}
+
+function createTestSetup() {
+	const transport = createMockTransport();
+	const session = new AgentSession({
+		sessionManager: createMockSessionManager(),
+		authStorage: createMockAuthStorage(),
+		environment: createMockEnvironment(),
+		systemPrompt: "Test prompt",
+	});
+	const handler = new RpcHandler({ session, transport });
+	handler.start();
+	return { transport, session, handler };
+}
+
+function getResponses(transport: MockTransport): RpcResponse[] {
+	return transport.sent.filter((m): m is RpcResponse => m.type === "response");
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("RpcHandler", () => {
+	test("responds to get_state", async () => {
+		const { transport, handler } = createTestSetup();
+
+		transport.inject({ type: "get_state", id: "req_1" });
+
+		// Allow async processing
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(true);
+		expect(responses[0].command).toBe("get_state");
+		expect(responses[0].id).toBe("req_1");
+
+		const data = responses[0].data as { thinkingLevel: string; isStreaming: boolean };
+		expect(data.thinkingLevel).toBe("off");
+		expect(data.isStreaming).toBe(false);
+
+		handler.stop();
+	});
+
+	test("responds to get_commands with empty list", async () => {
+		const { transport, handler } = createTestSetup();
+
+		transport.inject({ type: "get_commands", id: "req_2" });
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(true);
+
+		const data = responses[0].data as { commands: unknown[] };
+		expect(data.commands).toEqual([]);
+
+		handler.stop();
+	});
+
+	test("prompt returns success immediately (fire-and-forget)", async () => {
+		const { transport, handler } = createTestSetup();
+
+		transport.inject({ type: "prompt", id: "req_3", message: "Hello" });
+
+		// Prompt response should come back immediately
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses.length).toBeGreaterThanOrEqual(1);
+		const promptResponse = responses.find((r) => r.command === "prompt");
+		expect(promptResponse?.success).toBe(true);
+		expect(promptResponse?.id).toBe("req_3");
+
+		handler.stop();
+	});
+
+	test("abort responds with success", async () => {
+		const { transport, handler } = createTestSetup();
+
+		transport.inject({ type: "abort", id: "req_4" });
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(true);
+		expect(responses[0].command).toBe("abort");
+
+		handler.stop();
+	});
+
+	test("set_thinking_level responds with success", async () => {
+		const { transport, session, handler } = createTestSetup();
+
+		transport.inject({ type: "set_thinking_level", id: "req_5", level: "high" });
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(true);
+		expect(session.agent.state.thinkingLevel).toBe("high");
+
+		handler.stop();
+	});
+
+	test("set_model errors for unknown model", async () => {
+		const { transport, handler } = createTestSetup();
+
+		transport.inject({
+			type: "set_model",
+			id: "req_6",
+			provider: "nonexistent",
+			modelId: "fake-model",
+		});
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(false);
+		expect(responses[0].error).toContain("Unknown model");
+
+		handler.stop();
+	});
+
+	test("forwards session events to transport", async () => {
+		const { transport, session, handler } = createTestSetup();
+
+		// Emit a session event
+		session.agent.abort(); // triggers no event, but let's use compact
+		await session.compact();
+
+		const events = transport.sent.filter((m) => m.type === "event");
+		expect(events.length).toBeGreaterThanOrEqual(1);
+
+		handler.stop();
+	});
+
+	test("routes extension_ui_response to UIProvider", async () => {
+		const { transport, handler } = createTestSetup();
+
+		// The handler should route this without error — no pending request to resolve,
+		// but it shouldn't throw either
+		transport.inject({
+			type: "extension_ui_response",
+			id: "unknown-uuid",
+			confirmed: true,
+		});
+
+		// No crash means success
+		handler.stop();
+	});
+
+	test("stop closes transport and cleans up", async () => {
+		const { transport, handler } = createTestSetup();
+
+		handler.stop();
+
+		expect(transport.close).toHaveBeenCalled();
+	});
+
+	test("deferred shutdown stops after next command", async () => {
+		const { transport, handler } = createTestSetup();
+
+		handler.requestShutdown();
+
+		// Next command should trigger stop
+		transport.inject({ type: "abort", id: "req_7" });
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(transport.close).toHaveBeenCalled();
+	});
+
+	test("steer sends user message to session", async () => {
+		const { transport, session, handler } = createTestSetup();
+
+		const steerSpy = mock(() => {});
+		session.steer = steerSpy as typeof session.steer;
+
+		transport.inject({ type: "steer", id: "req_8", message: "Go faster" });
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(true);
+		expect(steerSpy).toHaveBeenCalled();
+
+		handler.stop();
+	});
+
+	test("follow_up sends user message to session", async () => {
+		const { transport, session, handler } = createTestSetup();
+
+		const followUpSpy = mock(() => {});
+		session.followUp = followUpSpy as typeof session.followUp;
+
+		transport.inject({ type: "follow_up", id: "req_9", message: "What next?" });
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(true);
+		expect(followUpSpy).toHaveBeenCalled();
+
+		handler.stop();
+	});
+
+	test("compact responds with success", async () => {
+		const { transport, handler } = createTestSetup();
+
+		transport.inject({ type: "compact", id: "req_10" });
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(true);
+		expect(responses[0].command).toBe("compact");
+
+		handler.stop();
+	});
+
+	test("dispatches unknown command type to extension commands", async () => {
+		const commandHandler = mock(async () => {});
+		const transport = createMockTransport();
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test",
+		});
+
+		await session.loadExtensions([
+			(api) => {
+				api.registerCommand("deploy", {
+					description: "Deploy the app",
+					handler: commandHandler,
+				});
+			},
+		]);
+
+		const handler = new RpcHandler({ session, transport });
+		handler.start();
+
+		// Send an unknown command type that matches an extension command
+		transport.inject({ type: "deploy", id: "req_ext", args: "production" } as RpcInboundMessage);
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(true);
+		expect(responses[0].command).toBe("deploy");
+		expect(commandHandler).toHaveBeenCalledTimes(1);
+
+		handler.stop();
+	});
+
+	test("returns error for completely unknown command type", async () => {
+		const { transport, handler } = createTestSetup();
+
+		transport.inject({ type: "nonexistent", id: "req_bad" } as RpcInboundMessage);
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(false);
+		expect(responses[0].error).toContain("Unknown command type");
+
+		handler.stop();
+	});
+
+	test("emits state_change event when state changes", async () => {
+		const { transport, session, handler } = createTestSetup();
+
+		// Compact fires compaction_start and compaction_end events
+		await session.compact();
+		await new Promise((r) => setTimeout(r, 10));
+
+		const events = transport.sent.filter((m): m is RpcAgentEvent => m.type === "event");
+		// Should have at least the lifecycle events
+		expect(events.length).toBeGreaterThanOrEqual(1);
+
+		handler.stop();
+	});
+
+	test("validates required message field on prompt", async () => {
+		const { transport, handler } = createTestSetup();
+
+		// Send prompt with empty message
+		transport.inject({ type: "prompt", id: "req_val", message: "" } as RpcInboundMessage);
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(false);
+		expect(responses[0].error).toContain("Missing required field");
+
+		handler.stop();
+	});
+
+	test("validates required message field on steer", async () => {
+		const { transport, handler } = createTestSetup();
+
+		transport.inject({ type: "steer", id: "req_val2", message: "" } as RpcInboundMessage);
+		await new Promise((r) => setTimeout(r, 10));
+
+		const responses = getResponses(transport);
+		expect(responses).toHaveLength(1);
+		expect(responses[0].success).toBe(false);
+		expect(responses[0].error).toContain("Missing required field");
+
+		handler.stop();
+	});
+});
+
+describe("RpcHandler UIProvider", () => {
+	test("uiProvider is available on handler", () => {
+		const transport = createMockTransport();
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test",
+		});
+		const handler = new RpcHandler({ session, transport });
+
+		expect(handler.uiProvider).toBeDefined();
+		expect(handler.uiProvider.dialog).toBeFunction();
+		expect(handler.uiProvider.confirm).toBeFunction();
+		expect(handler.uiProvider.input).toBeFunction();
+		expect(handler.uiProvider.select).toBeFunction();
+		expect(handler.uiProvider.notify).toBeFunction();
+	});
+
+	test("notify sends fire-and-forget request", () => {
+		const transport = createMockTransport();
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test",
+		});
+		const handler = new RpcHandler({ session, transport });
+
+		handler.uiProvider.notify("Hello", "info");
+
+		const requests = transport.sent.filter((m) => m.type === "extension_ui_request");
+		expect(requests).toHaveLength(1);
+
+		const req = requests[0] as { method: string; message: string };
+		expect(req.method).toBe("notify");
+		expect(req.message).toBe("Hello");
+	});
+
+	test("confirm sends request and resolves on response", async () => {
+		const transport = createMockTransport();
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test",
+		});
+		const handler = new RpcHandler({ session, transport });
+		handler.start();
+
+		const confirmPromise = handler.uiProvider.confirm("Title", "Are you sure?");
+
+		// Find the emitted request
+		const requests = transport.sent.filter((m) => m.type === "extension_ui_request");
+		expect(requests).toHaveLength(1);
+
+		const req = requests[0] as { id: string; method: string };
+		expect(req.method).toBe("confirm");
+
+		// Simulate client responding
+		transport.inject({
+			type: "extension_ui_response",
+			id: req.id,
+			confirmed: true,
+		});
+
+		const result = await confirmPromise;
+		expect(result).toBe(true);
+
+		handler.stop();
+	});
+
+	test("input sends request and resolves with value", async () => {
+		const transport = createMockTransport();
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test",
+		});
+		const handler = new RpcHandler({ session, transport });
+		handler.start();
+
+		const inputPromise = handler.uiProvider.input("Name?", "placeholder");
+
+		const requests = transport.sent.filter((m) => m.type === "extension_ui_request");
+		const req = requests[0] as { id: string };
+
+		transport.inject({
+			type: "extension_ui_response",
+			id: req.id,
+			value: "Alice",
+		});
+
+		const result = await inputPromise;
+		expect(result).toBe("Alice");
+
+		handler.stop();
+	});
+
+	test("select resolves with item at index", async () => {
+		const transport = createMockTransport();
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test",
+		});
+		const handler = new RpcHandler({ session, transport });
+		handler.start();
+
+		const items = [{ name: "a" }, { name: "b" }, { name: "c" }];
+		const selectPromise = handler.uiProvider.select("Pick one", items);
+
+		const requests = transport.sent.filter((m) => m.type === "extension_ui_request");
+		const req = requests[0] as { id: string };
+
+		// Client returns index "1" to pick second item
+		transport.inject({
+			type: "extension_ui_response",
+			id: req.id,
+			value: "1",
+		});
+
+		const result = await selectPromise;
+		expect(result).toEqual({ name: "b" });
+
+		handler.stop();
+	});
+
+	test("select resolves undefined on cancel", async () => {
+		const transport = createMockTransport();
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test",
+		});
+		const handler = new RpcHandler({ session, transport });
+		handler.start();
+
+		const selectPromise = handler.uiProvider.select("Pick one", ["a", "b"]);
+
+		const requests = transport.sent.filter((m) => m.type === "extension_ui_request");
+		const req = requests[0] as { id: string };
+
+		transport.inject({
+			type: "extension_ui_response",
+			id: req.id,
+			cancelled: true,
+		});
+
+		const result = await selectPromise;
+		expect(result).toBeUndefined();
+
+		handler.stop();
+	});
+});
+
+describe("AgentSession slash command interception", () => {
+	test("executes registered extension command on /prefix", async () => {
+		const commandHandler = mock(async () => {});
+
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test",
+		});
+
+		// Load an extension that registers a command
+		await session.loadExtensions([
+			(api) => {
+				api.registerCommand("hello", {
+					description: "Test command",
+					handler: commandHandler,
+				});
+			},
+		]);
+
+		// Send a /hello command — should be intercepted, not sent to LLM
+		await session.prompt("/hello world");
+
+		expect(commandHandler).toHaveBeenCalledTimes(1);
+		expect(commandHandler.mock.calls[0][0]).toBe("world");
+
+		await session.dispose();
+	});
+
+	test("falls through to LLM for unknown /commands", async () => {
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test",
+		});
+
+		// No extensions registered, so /unknown should fall through
+		// Since no model is set, this will error — but the point is it tries
+		// to send to the agent rather than being intercepted
+		try {
+			await session.prompt("/unknown command");
+		} catch {
+			// Expected — no model configured
+		}
+
+		await session.dispose();
+	});
+});

--- a/packages/otter-agent/src/rpc/rpc-handler.ts
+++ b/packages/otter-agent/src/rpc/rpc-handler.ts
@@ -1,0 +1,301 @@
+/**
+ * RpcHandler — dispatches RPC commands to an AgentSession and forwards
+ * events back over an abstract transport.
+ *
+ * Follows the same patterns as pi-coding-agent's `runRpcMode()`:
+ * - `prompt` is fire-and-forget (returns success immediately, events stream async)
+ * - All other commands are awaited before responding
+ * - Events are forwarded 1:1 from session to transport
+ * - Extension UI responses are routed to the RPC UIProvider
+ * - Shutdown is deferred (flag checked after each command)
+ */
+import type { AgentSession, AgentSessionEvent } from "../session/agent-session.js";
+import { createRpcUIProvider } from "./rpc-ui-provider.js";
+import type {
+	ExtensionUIResponse,
+	RpcCommand,
+	RpcInboundMessage,
+	RpcOutboundMessage,
+	RpcResponse,
+	RpcSessionState,
+	RpcTransport,
+} from "./types.js";
+
+export interface RpcHandlerOptions {
+	session: AgentSession;
+	transport: RpcTransport;
+}
+
+export class RpcHandler {
+	private readonly _session: AgentSession;
+	private readonly _transport: RpcTransport;
+	private readonly _resolveUIResponse: (response: ExtensionUIResponse) => void;
+	private readonly _rejectAllUI: (reason: string) => void;
+	private _unsubscribeSession: (() => void) | undefined;
+	private _shutdownRequested = false;
+	private _lastState: RpcSessionState | undefined;
+
+	/** The UIProvider to pass to AgentSessionOptions. */
+	readonly uiProvider;
+
+	constructor(options: RpcHandlerOptions) {
+		this._session = options.session;
+		this._transport = options.transport;
+
+		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(this._transport);
+		this.uiProvider = uiProvider;
+		this._resolveUIResponse = resolveResponse;
+		this._rejectAllUI = rejectAll;
+	}
+
+	/** Start listening for commands and forwarding events. */
+	start(): void {
+		// Capture initial state
+		this._lastState = this._snapshotState();
+
+		// Forward all session events to the transport, with state change detection
+		this._unsubscribeSession = this._session.subscribe((event: AgentSessionEvent) => {
+			this._transport.send({
+				type: "event",
+				event: event.type,
+				payload: event,
+			});
+			this._checkStateChange();
+		});
+
+		// Handle incoming messages
+		this._transport.onMessage((message: RpcInboundMessage) => {
+			if (message.type === "extension_ui_response") {
+				this._resolveUIResponse(message);
+				return;
+			}
+			this._handleCommand(message).catch((err) => {
+				this._send(
+					this._error(
+						(message as { id?: string }).id,
+						(message as { type: string }).type,
+						String(err),
+					),
+				);
+			});
+		});
+	}
+
+	/** Stop the handler, reject pending UI requests, and clean up. */
+	stop(): void {
+		this._rejectAllUI("RPC handler stopped");
+		this._unsubscribeSession?.();
+		this._unsubscribeSession = undefined;
+		this._transport.close?.();
+	}
+
+	// ─── Command Dispatch ────────────────────────────────────────────
+
+	private async _handleCommand(command: RpcCommand): Promise<void> {
+		switch (command.type) {
+			case "prompt": {
+				if (!command.message) {
+					this._send(this._error(command.id, "prompt", "Missing required field: message"));
+					break;
+				}
+				// Fire-and-forget — don't await, events stream async
+				this._session
+					.prompt(command.message, command.images)
+					.catch((e) =>
+						this._send(
+							this._error(command.id, "prompt", e instanceof Error ? e.message : String(e)),
+						),
+					);
+				this._send(this._success(command.id, "prompt"));
+				break;
+			}
+
+			case "steer": {
+				if (!command.message) {
+					this._send(this._error(command.id, "steer", "Missing required field: message"));
+					break;
+				}
+				this._session.steer({
+					role: "user",
+					content: command.message,
+					timestamp: Date.now(),
+				} as Parameters<typeof this._session.steer>[0]);
+				this._send(this._success(command.id, "steer"));
+				break;
+			}
+
+			case "follow_up": {
+				if (!command.message) {
+					this._send(this._error(command.id, "follow_up", "Missing required field: message"));
+					break;
+				}
+				this._session.followUp({
+					role: "user",
+					content: command.message,
+					timestamp: Date.now(),
+				} as Parameters<typeof this._session.followUp>[0]);
+				this._send(this._success(command.id, "follow_up"));
+				break;
+			}
+
+			case "abort": {
+				this._session.abort();
+				this._send(this._success(command.id, "abort"));
+				break;
+			}
+
+			case "set_model": {
+				if (!command.provider || !command.modelId) {
+					this._send(
+						this._error(command.id, "set_model", "Missing required fields: provider, modelId"),
+					);
+					break;
+				}
+				const model = this._session.modelRegistry.find(command.provider, command.modelId);
+				if (!model) {
+					this._send(
+						this._error(
+							command.id,
+							"set_model",
+							`Unknown model: ${command.provider}/${command.modelId}`,
+						),
+					);
+					break;
+				}
+				const ok = await this._session.setModel(model);
+				if (!ok) {
+					this._send(this._error(command.id, "set_model", "No API key available for model"));
+					break;
+				}
+				this._send(
+					this._success(command.id, "set_model", {
+						provider: command.provider,
+						modelId: command.modelId,
+					}),
+				);
+				break;
+			}
+
+			case "set_thinking_level": {
+				if (!command.level) {
+					this._send(
+						this._error(command.id, "set_thinking_level", "Missing required field: level"),
+					);
+					break;
+				}
+				this._session.setThinkingLevel(command.level);
+				this._send(this._success(command.id, "set_thinking_level"));
+				break;
+			}
+
+			case "compact": {
+				await this._session.compact(command.customInstructions);
+				this._send(this._success(command.id, "compact"));
+				break;
+			}
+
+			case "get_state": {
+				this._send(this._success(command.id, "get_state", this._snapshotState()));
+				break;
+			}
+
+			case "get_commands": {
+				const commands = this._session.extensionRunner.getCommands();
+				this._send(
+					this._success(command.id, "get_commands", {
+						commands: commands.map((c) => ({
+							name: c.name,
+							description: c.description,
+						})),
+					}),
+				);
+				break;
+			}
+
+			default: {
+				// Try extension command registry before returning error
+				await this._tryExtensionCommand(command);
+			}
+		}
+
+		this._checkShutdown();
+	}
+
+	/**
+	 * Attempt to dispatch an unknown command type to the extension command registry.
+	 * If no matching extension command is found, return an error response.
+	 */
+	private async _tryExtensionCommand(command: Record<string, unknown>): Promise<void> {
+		const type = command.type as string;
+		const id = command.id as string | undefined;
+		const args = typeof command.args === "string" ? command.args : "";
+		const handled = await this._session.extensionRunner.executeCommand(type, args);
+		if (handled) {
+			this._send(this._success(id, type));
+		} else {
+			this._send(this._error(id, type, `Unknown command type: ${type}`));
+		}
+	}
+
+	// ─── Shutdown ────────────────────────────────────────────────────
+
+	/** Request deferred shutdown (checked after each command). */
+	requestShutdown(): void {
+		this._shutdownRequested = true;
+	}
+
+	private _checkShutdown(): void {
+		if (this._shutdownRequested) {
+			this.stop();
+		}
+	}
+
+	// ─── State Change Detection ─────────────────────────────────────
+
+	private _snapshotState(): RpcSessionState {
+		const model = this._session.agent.state.model;
+		return {
+			model: model ? { provider: model.provider, modelId: model.id } : undefined,
+			thinkingLevel: this._session.agent.state.thinkingLevel,
+			isStreaming: this._session.agent.state.isStreaming,
+			messageCount: this._session.agent.state.messages.length,
+			pendingMessageCount: this._session.agent.hasQueuedMessages() ? 1 : 0,
+		};
+	}
+
+	private _checkStateChange(): void {
+		const current = this._snapshotState();
+		if (!this._lastState) {
+			this._lastState = current;
+			return;
+		}
+		if (
+			current.isStreaming !== this._lastState.isStreaming ||
+			current.thinkingLevel !== this._lastState.thinkingLevel ||
+			current.model?.provider !== this._lastState.model?.provider ||
+			current.model?.modelId !== this._lastState.model?.modelId ||
+			current.messageCount !== this._lastState.messageCount
+		) {
+			this._lastState = current;
+			this._transport.send({
+				type: "event",
+				event: "state_change",
+				payload: current,
+			});
+		}
+	}
+
+	// ─── Helpers ─────────────────────────────────────────────────────
+
+	private _send(message: RpcOutboundMessage): void {
+		this._transport.send(message);
+	}
+
+	private _success(id: string | undefined, command: string, data?: unknown): RpcResponse {
+		return { type: "response", id, command, success: true, data };
+	}
+
+	private _error(id: string | undefined, command: string, error: string): RpcResponse {
+		return { type: "response", id, command, success: false, error };
+	}
+}

--- a/packages/otter-agent/src/rpc/rpc-ui-provider.ts
+++ b/packages/otter-agent/src/rpc/rpc-ui-provider.ts
@@ -1,0 +1,119 @@
+/**
+ * RPC UIProvider — bridges extension UI calls to the RPC transport.
+ *
+ * When an extension calls a UIProvider method (dialog, confirm, input,
+ * select, notify), this implementation emits an `extension_ui_request`
+ * message over the transport and waits for the matching
+ * `extension_ui_response` from the client.
+ *
+ * Follows the same UUID-based pending-promise pattern as pi-coding-agent.
+ */
+import type { UIProvider } from "../interfaces/ui-provider.js";
+import type { ExtensionUIRequest, ExtensionUIResponse, RpcTransport } from "./types.js";
+
+interface PendingRequest {
+	resolve: (response: ExtensionUIResponse) => void;
+	reject: (error: Error) => void;
+}
+
+/**
+ * Create a UIProvider that bridges extension UI calls to an RPC transport.
+ *
+ * Call `resolveResponse()` when an `extension_ui_response` arrives from
+ * the client. Call `rejectAll()` during shutdown to clean up pending
+ * requests.
+ */
+export function createRpcUIProvider(transport: RpcTransport): {
+	uiProvider: UIProvider;
+	resolveResponse: (response: ExtensionUIResponse) => void;
+	rejectAll: (reason: string) => void;
+} {
+	const pending = new Map<string, PendingRequest>();
+
+	function createDialogPromise<T>(
+		request: ExtensionUIRequest,
+		extract: (response: ExtensionUIResponse) => T,
+	): Promise<T> {
+		return new Promise<T>((resolve, reject) => {
+			pending.set(request.id, {
+				resolve: (response) => resolve(extract(response)),
+				reject,
+			});
+			transport.send(request);
+		});
+	}
+
+	const uiProvider: UIProvider = {
+		dialog(title: string, body: string): Promise<void> {
+			const id = crypto.randomUUID();
+			return createDialogPromise(
+				{ type: "extension_ui_request", id, method: "dialog", title, body },
+				() => undefined,
+			);
+		},
+
+		confirm(title: string, body: string): Promise<boolean> {
+			const id = crypto.randomUUID();
+			return createDialogPromise(
+				{ type: "extension_ui_request", id, method: "confirm", title, body },
+				(r) => (r.cancelled ? false : (r.confirmed ?? false)),
+			);
+		},
+
+		input(title: string, placeholder?: string): Promise<string | undefined> {
+			const id = crypto.randomUUID();
+			return createDialogPromise(
+				{ type: "extension_ui_request", id, method: "input", title, placeholder },
+				(r) => (r.cancelled ? undefined : r.value),
+			);
+		},
+
+		select<T>(title: string, items: T[]): Promise<T | undefined> {
+			const id = crypto.randomUUID();
+			return createDialogPromise(
+				{ type: "extension_ui_request", id, method: "select", title, items },
+				(r) => {
+					if (r.cancelled) return undefined;
+					// Client returns the string value; find matching item by index
+					// or string comparison for simple types.
+					if (r.value === undefined) return undefined;
+					const index = Number(r.value);
+					if (!Number.isNaN(index) && index >= 0 && index < items.length) {
+						return items[index];
+					}
+					return undefined;
+				},
+			);
+		},
+
+		notify(message: string, type?: "info" | "warning" | "error"): void {
+			const id = crypto.randomUUID();
+			// Fire-and-forget — no response expected
+			transport.send({
+				type: "extension_ui_request",
+				id,
+				method: "notify",
+				message,
+				notifyType: type,
+			});
+		},
+	};
+
+	function resolveResponse(response: ExtensionUIResponse): void {
+		const entry = pending.get(response.id);
+		if (entry) {
+			pending.delete(response.id);
+			entry.resolve(response);
+		}
+	}
+
+	function rejectAll(reason: string): void {
+		const error = new Error(reason);
+		for (const entry of pending.values()) {
+			entry.reject(error);
+		}
+		pending.clear();
+	}
+
+	return { uiProvider, resolveResponse, rejectAll };
+}

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -195,6 +195,12 @@ export class AgentSession {
 	 * always restored before the next turn.
 	 */
 	async prompt(input: string, images?: ImageContent[]): Promise<void> {
+		// Intercept extension commands (e.g., "/commandName args")
+		if (input.startsWith("/")) {
+			const handled = await this._tryExecuteExtensionCommand(input);
+			if (handled) return;
+		}
+
 		const baseSystemPrompt = this._getCurrentSystemPrompt();
 
 		// Fire before_agent_start — extensions can override the system prompt
@@ -513,6 +519,17 @@ export class AgentSession {
 		return [...this._activeToolNames]
 			.map((name) => this._toolRegistry.get(name))
 			.filter((t): t is AgentTool => t !== undefined);
+	}
+
+	/**
+	 * Try to execute a `/command args` extension command.
+	 * Returns true if the command was found (even if it errored).
+	 */
+	private async _tryExecuteExtensionCommand(text: string): Promise<boolean> {
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+		return this._extensionRunner.executeCommand(commandName, args);
 	}
 
 	/** Apply tool changes to the Agent (update tools and rebuild system prompt). */


### PR DESCRIPTION
## Summary

Implements the RPC handler that sits between  and , processing incoming commands, dispatching them to the session, and forwarding events back to the client.

Depends on (and builds on): #3 (AgentSession), #4 (extension loading), #6 (RPC protocol).

## Changes

- **RpcHandler** — dispatches all 9 built-in commands (, , , , , , , , ) to  over an abstract 
- **Event forwarding** — subscribes to all  events and forwards them 1:1, with state change detection that emits  events when model/thinking/streaming/message count changes
- **Extension commands** — unknown command types fall through to the extension command registry; also intercepts  inputs in  before reaching the LLM
- **RPC UIProvider** —  bridges  methods (dialog, confirm, input, select, notify) to / messages using UUID-based pending promises
- **Public API** — exports , , and 

## Testing

27 new tests covering:
- All built-in command dispatch (success + error paths)
- Fire-and-forget prompt behavior
- Extension command dispatch for unknown command types
- Event forwarding and state change detection
- UIProvider request/response flow (confirm, input, select, notify, cancel)
- Lifecycle (start/stop, deferred shutdown)
- Slash command interception in AgentSession

All 134 tests pass. Build and lint clean.

Closes #7