### PR TITLE
refactor: remove upstream type re-exports from public API surface

### DIFF
--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -117,21 +117,3 @@ export type {
 	SetThinkingLevelCommand,
 	SteerCommand,
 } from "./rpc/index.js";
-
-// Re-exports from pi-agent-core
-export type {
-	AgentContext,
-	AgentEvent,
-	AgentMessage,
-	AgentState,
-	AgentTool,
-	AgentToolCall,
-	AgentToolResult,
-	AgentToolUpdateCallback,
-	AfterToolCallContext,
-	AfterToolCallResult,
-	BeforeToolCallContext,
-	BeforeToolCallResult,
-	ThinkingLevel,
-	ToolExecutionMode,
-} from "@mariozechner/pi-agent-core";


### PR DESCRIPTION
## Summary

Remove upstream type re-exports from `@otter-agent/core`'s public API surface. Consumers who need low-level types from `pi-agent-core` or `pi-ai` should import them directly, consistent with how `pi-coding-agent` handles this.

## Changes

- Removed 15 `pi-agent-core` type re-exports from `src/index.ts` (`AgentContext`, `AgentEvent`, `AgentMessage`, `AgentState`, `AgentTool`, `AgentToolCall`, `AgentToolResult`, `AgentToolUpdateCallback`, `AfterToolCallContext`, `AfterToolCallResult`, `BeforeToolCallContext`, `BeforeToolCallResult`, `ThinkingLevel`, `ToolExecutionMode`)
- Audited all internal source files — no OtterAgent-defined types were missing from the export surface
- No internal or test imports needed updating (all use direct relative imports to `pi-agent-core`)

## Verification

- Build passes (`tsc`)
- All 134 tests pass
- Lint clean (Biome)

Closes #8
