### PR TITLE
feat: return model and thinking level from SessionManager.buildSessionContext()

### DIFF
--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -4,6 +4,7 @@ export type {
 	AuthStorage,
 	EntryId,
 	ReadonlySessionManager,
+	SessionContext,
 	SessionManager,
 	ToolDefinition,
 	UIProvider,

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -1,5 +1,10 @@
 export type { AgentEnvironment } from "./agent-environment.js";
 export type { AuthStorage } from "./auth-storage.js";
-export type { SessionManager, ReadonlySessionManager, EntryId } from "./session-manager.js";
+export type {
+	SessionContext,
+	SessionManager,
+	ReadonlySessionManager,
+	EntryId,
+} from "./session-manager.js";
 export type { ToolDefinition } from "./tool-definition.js";
 export type { UIProvider } from "./ui-provider.js";

--- a/packages/otter-agent/src/interfaces/session-manager.ts
+++ b/packages/otter-agent/src/interfaces/session-manager.ts
@@ -1,10 +1,25 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
 
 /**
  * A unique identifier for a session entry.
  */
 export type EntryId = string;
+
+/**
+ * The result of building session context for the LLM.
+ *
+ * Contains the ordered message list along with the model and thinking
+ * level that were active when the session was last used.
+ */
+export interface SessionContext {
+	/** Ordered array of messages suitable for the LLM context. */
+	messages: AgentMessage[];
+	/** The thinking level at the end of the session. Defaults to "off". */
+	thinkingLevel: ThinkingLevel;
+	/** The model in use at the end of the session, or null if unknown. */
+	model: { provider: string; modelId: string } | null;
+}
 
 /**
  * Minimal interface for persisting conversation state.
@@ -26,7 +41,7 @@ export interface SessionManager {
 	appendMessage(message: AgentMessage): EntryId;
 
 	/**
-	 * Build the message list to send to the LLM.
+	 * Build the session context for the LLM.
 	 *
 	 * Handles compaction: if a compaction marker exists, messages before
 	 * `firstKeptEntryId` are discarded and the compaction summary is
@@ -34,11 +49,13 @@ export interface SessionManager {
 	 *
 	 * Custom message entries (from `appendCustomMessageEntry`) are included.
 	 * Metadata entries (model change, thinking level, labels) and custom
-	 * entries (from `appendCustomEntry`) are excluded.
+	 * entries (from `appendCustomEntry`) are excluded from the messages
+	 * array, but model and thinking level are extracted from their
+	 * respective metadata entries.
 	 *
-	 * @returns An ordered array of messages suitable for the LLM context.
+	 * @returns The session context including messages, thinking level, and model.
 	 */
-	buildSessionContext(): AgentMessage[];
+	buildSessionContext(): SessionContext;
 
 	/**
 	 * Record a compaction event. When `buildSessionContext()` is called,

--- a/packages/otter-agent/src/rpc/rpc-handler.test.ts
+++ b/packages/otter-agent/src/rpc/rpc-handler.test.ts
@@ -18,7 +18,7 @@ function createMockSessionManager(): SessionManager {
 	let entryCounter = 0;
 	return {
 		appendMessage: mock(() => String(++entryCounter)),
-		buildSessionContext: mock(() => []),
+		buildSessionContext: mock(() => ({ messages: [], thinkingLevel: "off", model: null })),
 		compact: mock(() => String(++entryCounter)),
 		appendCustomEntry: mock(() => String(++entryCounter)),
 		appendCustomMessageEntry: mock(() => String(++entryCounter)),

--- a/packages/otter-agent/src/session/agent-session.test.ts
+++ b/packages/otter-agent/src/session/agent-session.test.ts
@@ -13,7 +13,7 @@ function createMockSessionManager(): SessionManager {
 	let entryCounter = 0;
 	return {
 		appendMessage: mock(() => String(++entryCounter)),
-		buildSessionContext: mock(() => []),
+		buildSessionContext: mock(() => ({ messages: [], thinkingLevel: "off", model: null })),
 		compact: mock(() => String(++entryCounter)),
 		appendCustomEntry: mock(() => String(++entryCounter)),
 		appendCustomMessageEntry: mock(() => String(++entryCounter)),


### PR DESCRIPTION
## Summary

Closes #18

Changes  to return a  object containing , , and  instead of just . This enables session restore flows to recover the active model and thinking level from persisted session state.

## Changes

- ** interface** — New type with , , and 
- ** return type** — Changed from  to 
- **** — Automatically updated via 
- **Test mocks** — Updated in  and 
- **Exports** —  exported from  and package root

## Acceptance Criteria

- [x] `SessionManager.buildSessionContext()` returns an object with `messages`, `thinkingLevel`, and `model`
- [x] `ReadonlySessionManager` type is updated accordingly
- [x] All existing consumers and tests are updated
- [x] Build and lint pass

## Verification

- Build: ✅
- Tests: ✅ (134/134 pass)
- Lint: ✅ (0 errors)
- Independent review: ✅ (pi agent via zai/glm-5-turbo — approved)