### PR TITLE
feat: add in-memory SessionManager implementation

### DIFF
--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -5,11 +5,15 @@ export type {
 	EntryId,
 	ReadonlySessionManager,
 	SessionContext,
-	SessionManager,
 	ToolDefinition,
 	UIProvider,
 } from "./interfaces/index.js";
 export { noOpUIProvider } from "./interfaces/ui.js";
+
+// Built-in SessionManager implementations.
+// SessionManager is exported as both a type (the interface) and a value
+// (namespace with factory methods) via declaration merging in session-managers/index.ts.
+export { createInMemorySessionManager, SessionManager } from "./session-managers/index.js";
 
 // ExtensionsAPI
 export type {

--- a/packages/otter-agent/src/interfaces/session-manager.ts
+++ b/packages/otter-agent/src/interfaces/session-manager.ts
@@ -64,10 +64,17 @@ export interface SessionManager {
 	 * @param summary - The compaction summary text.
 	 * @param firstKeptEntryId - The ID of the first entry to keep after
 	 *   compaction. All entries before this are replaced by the summary.
+	 * @param tokensBefore - The number of tokens in the context before
+	 *   compaction. Used for display purposes. Defaults to 0 if unknown.
 	 * @param details - Optional implementation-specific compaction metadata.
 	 * @returns The unique ID of the compaction entry.
 	 */
-	compact(summary: string, firstKeptEntryId: EntryId, details?: unknown): EntryId;
+	compact(
+		summary: string,
+		firstKeptEntryId: EntryId,
+		tokensBefore?: number,
+		details?: unknown,
+	): EntryId;
 
 	/**
 	 * Persist extension state that is NOT included in LLM context.

--- a/packages/otter-agent/src/session-managers/in-memory-session-manager.test.ts
+++ b/packages/otter-agent/src/session-managers/in-memory-session-manager.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX } from "../session/messages.js";
+import { createInMemorySessionManager } from "./in-memory-session-manager.js";
+import { SessionManager } from "./index.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeUserMessage(text: string): AgentMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+	};
+}
+
+function makeAssistantMessage(text: string): AgentMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+	};
+}
+
+// ─── buildSessionContext defaults ─────────────────────────────────────────────
+
+describe("buildSessionContext — empty session", () => {
+	test("returns empty messages, thinkingLevel 'off', and null model", () => {
+		const sm = createInMemorySessionManager();
+		const ctx = sm.buildSessionContext();
+		expect(ctx.messages).toEqual([]);
+		expect(ctx.thinkingLevel).toBe("off");
+		expect(ctx.model).toBeNull();
+	});
+});
+
+// ─── appendMessage ────────────────────────────────────────────────────────────
+
+describe("appendMessage", () => {
+	test("returns a unique EntryId", () => {
+		const sm = createInMemorySessionManager();
+		const id1 = sm.appendMessage(makeUserMessage("hello"));
+		const id2 = sm.appendMessage(makeAssistantMessage("hi"));
+		expect(id1).toBeTruthy();
+		expect(id2).toBeTruthy();
+		expect(id1).not.toBe(id2);
+	});
+
+	test("messages appear in buildSessionContext in order", () => {
+		const sm = createInMemorySessionManager();
+		const m1 = makeUserMessage("first");
+		const m2 = makeAssistantMessage("second");
+		sm.appendMessage(m1);
+		sm.appendMessage(m2);
+		const { messages } = sm.buildSessionContext();
+		expect(messages).toHaveLength(2);
+		expect(messages[0]).toEqual(m1);
+		expect(messages[1]).toEqual(m2);
+	});
+});
+
+// ─── appendCustomMessageEntry ─────────────────────────────────────────────────
+
+describe("appendCustomMessageEntry", () => {
+	test("returns a unique EntryId", () => {
+		const sm = createInMemorySessionManager();
+		const id = sm.appendCustomMessageEntry("ext-1", "hello", true);
+		expect(id).toBeTruthy();
+	});
+
+	test("content is included in buildSessionContext messages as custom role", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendCustomMessageEntry("ext-1", "injected content", true);
+		const { messages } = sm.buildSessionContext();
+		expect(messages).toHaveLength(1);
+		expect(messages[0].role).toBe("custom");
+		// @ts-expect-error — accessing custom role field
+		expect(messages[0].content).toBe("injected content");
+		// @ts-expect-error — accessing custom role field
+		expect(messages[0].customType).toBe("ext-1");
+		// @ts-expect-error — accessing custom role field
+		expect(messages[0].display).toBe(true);
+	});
+
+	test("details are stored and exposed on the message", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendCustomMessageEntry("ext-1", "msg", false, { foo: "bar" });
+		const { messages } = sm.buildSessionContext();
+		// @ts-expect-error — accessing custom role field
+		expect(messages[0].details).toEqual({ foo: "bar" });
+	});
+
+	test("content as array of content blocks is preserved", () => {
+		const sm = createInMemorySessionManager();
+		const content = [{ type: "text" as const, text: "block" }];
+		sm.appendCustomMessageEntry("ext-1", content, false);
+		const { messages } = sm.buildSessionContext();
+		// @ts-expect-error — accessing custom role field
+		expect(messages[0].content).toEqual(content);
+	});
+});
+
+// ─── appendCustomEntry ────────────────────────────────────────────────────────
+
+describe("appendCustomEntry", () => {
+	test("returns a unique EntryId", () => {
+		const sm = createInMemorySessionManager();
+		const id = sm.appendCustomEntry("ext-1", { state: true });
+		expect(id).toBeTruthy();
+	});
+
+	test("does NOT appear in buildSessionContext messages", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendCustomEntry("ext-1", { state: true });
+		const { messages } = sm.buildSessionContext();
+		expect(messages).toHaveLength(0);
+	});
+});
+
+// ─── appendModelChange ────────────────────────────────────────────────────────
+
+describe("appendModelChange", () => {
+	test("returns a unique EntryId", () => {
+		const sm = createInMemorySessionManager();
+		const id = sm.appendModelChange({ provider: "anthropic", modelId: "claude-opus" }, "off");
+		expect(id).toBeTruthy();
+	});
+
+	test("does NOT appear in buildSessionContext messages", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendModelChange({ provider: "anthropic", modelId: "claude-opus" }, "off");
+		const { messages } = sm.buildSessionContext();
+		expect(messages).toHaveLength(0);
+	});
+
+	test("is reflected in buildSessionContext model", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendModelChange({ provider: "anthropic", modelId: "claude-opus" }, "off");
+		const { model } = sm.buildSessionContext();
+		expect(model).toEqual({ provider: "anthropic", modelId: "claude-opus" });
+	});
+
+	test("is reflected in buildSessionContext thinkingLevel", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendModelChange({ provider: "anthropic", modelId: "claude-opus" }, "high");
+		const { thinkingLevel } = sm.buildSessionContext();
+		expect(thinkingLevel).toBe("high");
+	});
+
+	test("latest model change wins", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendModelChange({ provider: "anthropic", modelId: "claude-haiku" }, "off");
+		sm.appendModelChange({ provider: "anthropic", modelId: "claude-opus" }, "low");
+		const { model, thinkingLevel } = sm.buildSessionContext();
+		expect(model).toEqual({ provider: "anthropic", modelId: "claude-opus" });
+		expect(thinkingLevel).toBe("low");
+	});
+});
+
+// ─── appendThinkingLevelChange ────────────────────────────────────────────────
+
+describe("appendThinkingLevelChange", () => {
+	test("returns a unique EntryId", () => {
+		const sm = createInMemorySessionManager();
+		const id = sm.appendThinkingLevelChange("high");
+		expect(id).toBeTruthy();
+	});
+
+	test("does NOT appear in buildSessionContext messages", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendThinkingLevelChange("high");
+		const { messages } = sm.buildSessionContext();
+		expect(messages).toHaveLength(0);
+	});
+
+	test("is reflected in buildSessionContext thinkingLevel", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendThinkingLevelChange("low");
+		const { thinkingLevel } = sm.buildSessionContext();
+		expect(thinkingLevel).toBe("low");
+	});
+
+	test("latest thinkingLevelChange wins over a prior modelChange", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendModelChange({ provider: "anthropic", modelId: "claude-opus" }, "high");
+		sm.appendThinkingLevelChange("off");
+		const { thinkingLevel } = sm.buildSessionContext();
+		expect(thinkingLevel).toBe("off");
+	});
+});
+
+// ─── appendLabel ──────────────────────────────────────────────────────────────
+
+describe("appendLabel", () => {
+	test("returns a unique EntryId", () => {
+		const sm = createInMemorySessionManager();
+		const msgId = sm.appendMessage(makeUserMessage("hi"));
+		const labelId = sm.appendLabel("important", msgId);
+		expect(labelId).toBeTruthy();
+		expect(labelId).not.toBe(msgId);
+	});
+
+	test("does NOT affect buildSessionContext messages", () => {
+		const sm = createInMemorySessionManager();
+		const msgId = sm.appendMessage(makeUserMessage("hi"));
+		sm.appendLabel("important", msgId);
+		const { messages } = sm.buildSessionContext();
+		expect(messages).toHaveLength(1);
+	});
+});
+
+// ─── compact ──────────────────────────────────────────────────────────────────
+
+describe("compact", () => {
+	test("returns a unique EntryId", () => {
+		const sm = createInMemorySessionManager();
+		const msgId = sm.appendMessage(makeUserMessage("hi"));
+		const compactId = sm.compact("summary", msgId);
+		expect(compactId).toBeTruthy();
+		expect(compactId).not.toBe(msgId);
+	});
+
+	test("messages before firstKeptEntryId are replaced by CompactionSummaryMessage", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendMessage(makeUserMessage("old 1"));
+		sm.appendMessage(makeAssistantMessage("old 2"));
+		const keepId = sm.appendMessage(makeUserMessage("keep this"));
+		sm.appendMessage(makeAssistantMessage("after keep"));
+		sm.compact("This is the summary", keepId);
+
+		const { messages } = sm.buildSessionContext();
+		// compactionSummary + "keep this" + "after keep"
+		expect(messages).toHaveLength(3);
+		expect(messages[0].role).toBe("compactionSummary");
+		// @ts-expect-error — accessing compactionSummary role field
+		expect(messages[0].summary).toBe("This is the summary");
+		expect(messages[1].role).toBe("user");
+		expect(messages[2].role).toBe("assistant");
+	});
+
+	test("tokensBefore is stored and surfaced on CompactionSummaryMessage", () => {
+		const sm = createInMemorySessionManager();
+		const keepId = sm.appendMessage(makeUserMessage("keep"));
+		sm.compact("summary", keepId, 42000);
+
+		const { messages } = sm.buildSessionContext();
+		expect(messages[0].role).toBe("compactionSummary");
+		// @ts-expect-error — accessing compactionSummary role field
+		expect(messages[0].tokensBefore).toBe(42000);
+	});
+
+	test("tokensBefore defaults to 0 when omitted", () => {
+		const sm = createInMemorySessionManager();
+		const keepId = sm.appendMessage(makeUserMessage("keep"));
+		sm.compact("summary", keepId);
+
+		const { messages } = sm.buildSessionContext();
+		// @ts-expect-error — accessing compactionSummary role field
+		expect(messages[0].tokensBefore).toBe(0);
+	});
+
+	test("messages appended after compact() are included after the summary", () => {
+		const sm = createInMemorySessionManager();
+		const keepId = sm.appendMessage(makeUserMessage("keep"));
+		sm.compact("summary", keepId);
+		sm.appendMessage(makeAssistantMessage("new message"));
+
+		const { messages } = sm.buildSessionContext();
+		// compactionSummary + "keep" + "new message"
+		expect(messages).toHaveLength(3);
+		expect(messages[2].role).toBe("assistant");
+	});
+
+	test("firstKeptEntryId not found — full compaction fallback (summary only)", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendMessage(makeUserMessage("old 1"));
+		sm.appendMessage(makeAssistantMessage("old 2"));
+		sm.compact("summary", "nonexistent-id");
+
+		const { messages } = sm.buildSessionContext();
+		expect(messages).toHaveLength(1);
+		expect(messages[0].role).toBe("compactionSummary");
+		// @ts-expect-error — accessing compactionSummary role field
+		expect(messages[0].summary).toBe("summary");
+	});
+
+	test("firstKeptEntryId not found still includes messages appended after compact()", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendMessage(makeUserMessage("old"));
+		sm.compact("summary", "nonexistent-id");
+		sm.appendMessage(makeAssistantMessage("new after compact"));
+
+		const { messages } = sm.buildSessionContext();
+		expect(messages).toHaveLength(2);
+		expect(messages[0].role).toBe("compactionSummary");
+		expect(messages[1].role).toBe("assistant");
+	});
+
+	test("latest compaction wins when compact() is called multiple times", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendMessage(makeUserMessage("old 1"));
+		const firstKeepId = sm.appendMessage(makeUserMessage("first keep"));
+		sm.compact("first summary", firstKeepId);
+
+		sm.appendMessage(makeAssistantMessage("middle"));
+		const secondKeepId = sm.appendMessage(makeUserMessage("second keep"));
+		sm.compact("second summary", secondKeepId);
+
+		sm.appendMessage(makeAssistantMessage("latest"));
+
+		const { messages } = sm.buildSessionContext();
+		// Only the second compaction applies.
+		expect(messages[0].role).toBe("compactionSummary");
+		// @ts-expect-error — accessing compactionSummary role field
+		expect(messages[0].summary).toBe("second summary");
+		// "second keep" + "latest"
+		expect(messages).toHaveLength(3);
+	});
+
+	test("compactionSummaryMessage content wraps summary in expected tags when converted to LLM", () => {
+		const sm = createInMemorySessionManager();
+		const keepId = sm.appendMessage(makeUserMessage("keep"));
+		sm.compact("my summary text", keepId);
+
+		const { messages } = sm.buildSessionContext();
+		expect(messages[0].role).toBe("compactionSummary");
+		// @ts-expect-error — accessing compactionSummary role field
+		const summary: string = messages[0].summary;
+		// Verify the summary text is stored as-is (convertToLlm wraps it in tags separately)
+		expect(summary).toBe("my summary text");
+	});
+});
+
+// ─── unique IDs across all entry types ───────────────────────────────────────
+
+describe("EntryId uniqueness", () => {
+	test("all append methods return unique IDs across the same instance", () => {
+		const sm = createInMemorySessionManager();
+		const ids = [
+			sm.appendMessage(makeUserMessage("m")),
+			sm.appendCustomMessageEntry("ext", "c", true),
+			sm.appendCustomEntry("ext", {}),
+			sm.appendModelChange({ provider: "p", modelId: "m" }, "off"),
+			sm.appendThinkingLevelChange("low"),
+			sm.appendLabel("lbl", "1"),
+		];
+		const unique = new Set(ids);
+		expect(unique.size).toBe(ids.length);
+	});
+});
+
+// ─── SessionManager.inMemory() factory ───────────────────────────────────────
+
+describe("SessionManager.inMemory()", () => {
+	test("returns a working SessionManager instance", () => {
+		const sm = SessionManager.inMemory();
+		expect(sm).toBeDefined();
+		const ctx = sm.buildSessionContext();
+		expect(ctx.messages).toEqual([]);
+		expect(ctx.thinkingLevel).toBe("off");
+		expect(ctx.model).toBeNull();
+	});
+
+	test("each call returns an independent instance", () => {
+		const sm1 = SessionManager.inMemory();
+		const sm2 = SessionManager.inMemory();
+		sm1.appendMessage(makeUserMessage("only in sm1"));
+		expect(sm1.buildSessionContext().messages).toHaveLength(1);
+		expect(sm2.buildSessionContext().messages).toHaveLength(0);
+	});
+
+	test("satisfies the SessionManager type (type-level check via createInMemorySessionManager)", () => {
+		// Both factory paths should produce the same shape.
+		const sm1 = SessionManager.inMemory();
+		const sm2 = createInMemorySessionManager();
+		expect(typeof sm1.appendMessage).toBe("function");
+		expect(typeof sm2.appendMessage).toBe("function");
+	});
+});

--- a/packages/otter-agent/src/session-managers/in-memory-session-manager.ts
+++ b/packages/otter-agent/src/session-managers/in-memory-session-manager.ts
@@ -1,0 +1,183 @@
+import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
+import type { EntryId, SessionContext, SessionManager } from "../interfaces/session-manager.js";
+import { createCompactionSummaryMessage, createCustomMessage } from "../session/messages.js";
+
+type InMemoryEntry =
+	| { type: "message"; id: EntryId; message: AgentMessage }
+	| {
+			type: "customMessage";
+			id: EntryId;
+			customType: string;
+			content: string | (TextContent | ImageContent)[];
+			display: boolean;
+			details?: unknown;
+	  }
+	| { type: "customEntry"; id: EntryId; customType: string; data?: unknown }
+	| {
+			type: "modelChange";
+			id: EntryId;
+			model: { provider: string; modelId: string };
+			thinkingLevel: string;
+	  }
+	| { type: "thinkingLevelChange"; id: EntryId; thinkingLevel: string }
+	| {
+			type: "compaction";
+			id: EntryId;
+			summary: string;
+			firstKeptEntryId: EntryId;
+			tokensBefore: number;
+			details?: unknown;
+	  }
+	| { type: "label"; id: EntryId; label: string; targetEntryId: EntryId };
+
+class InMemorySessionManager implements SessionManager {
+	private readonly entries: InMemoryEntry[] = [];
+	private nextId = 1;
+
+	private generateId(): EntryId {
+		return String(this.nextId++);
+	}
+
+	appendMessage(message: AgentMessage): EntryId {
+		const id = this.generateId();
+		this.entries.push({ type: "message", id, message });
+		return id;
+	}
+
+	appendCustomMessageEntry(
+		customType: string,
+		content: string | (TextContent | ImageContent)[],
+		display: boolean,
+		details?: unknown,
+	): EntryId {
+		const id = this.generateId();
+		this.entries.push({ type: "customMessage", id, customType, content, display, details });
+		return id;
+	}
+
+	appendCustomEntry(customType: string, data?: unknown): EntryId {
+		const id = this.generateId();
+		this.entries.push({ type: "customEntry", id, customType, data });
+		return id;
+	}
+
+	appendModelChange(model: { provider: string; modelId: string }, thinkingLevel: string): EntryId {
+		const id = this.generateId();
+		this.entries.push({ type: "modelChange", id, model, thinkingLevel });
+		return id;
+	}
+
+	appendThinkingLevelChange(thinkingLevel: string): EntryId {
+		const id = this.generateId();
+		this.entries.push({ type: "thinkingLevelChange", id, thinkingLevel });
+		return id;
+	}
+
+	compact(
+		summary: string,
+		firstKeptEntryId: EntryId,
+		tokensBefore = 0,
+		details?: unknown,
+	): EntryId {
+		const id = this.generateId();
+		this.entries.push({ type: "compaction", id, summary, firstKeptEntryId, tokensBefore, details });
+		return id;
+	}
+
+	appendLabel(label: string, targetEntryId: EntryId): EntryId {
+		const id = this.generateId();
+		this.entries.push({ type: "label", id, label, targetEntryId });
+		return id;
+	}
+
+	buildSessionContext(): SessionContext {
+		// Find the latest compaction entry.
+		let latestCompaction: Extract<InMemoryEntry, { type: "compaction" }> | undefined;
+		for (const entry of this.entries) {
+			if (entry.type === "compaction") {
+				latestCompaction = entry;
+			}
+		}
+
+		// Collect messages.
+		let messages: AgentMessage[];
+
+		if (latestCompaction !== undefined) {
+			const compaction = latestCompaction;
+			const compactionSummary = createCompactionSummaryMessage(
+				compaction.summary,
+				compaction.tokensBefore,
+			);
+
+			// Find the index of firstKeptEntryId.
+			const firstKeptIndex = this.entries.findIndex((e) => e.id === compaction.firstKeptEntryId);
+
+			if (firstKeptIndex === -1) {
+				// firstKeptEntryId not found — full compaction fallback: no pre-compaction
+				// messages kept, but messages appended after compact() are still included.
+				const compactionIndex = this.entries.indexOf(latestCompaction);
+				const afterCompaction = this.entries.slice(compactionIndex + 1);
+				messages = [compactionSummary, ...this.extractMessages(afterCompaction)];
+			} else {
+				// Include message-bearing entries from firstKeptEntryId onward,
+				// but stop before (and excluding) the compaction entry itself.
+				const compactionIndex = this.entries.indexOf(latestCompaction);
+				const tail = this.entries.slice(firstKeptIndex, compactionIndex);
+				const tailMessages = this.extractMessages(tail);
+
+				// Also include any message-bearing entries after the compaction entry.
+				const afterCompaction = this.entries.slice(compactionIndex + 1);
+				const afterMessages = this.extractMessages(afterCompaction);
+
+				messages = [compactionSummary, ...tailMessages, ...afterMessages];
+			}
+		} else {
+			messages = this.extractMessages(this.entries);
+		}
+
+		// Extract the latest model and thinking level from metadata entries.
+		let model: { provider: string; modelId: string } | null = null;
+		let thinkingLevel = "off";
+
+		for (const entry of this.entries) {
+			if (entry.type === "modelChange") {
+				model = entry.model;
+				thinkingLevel = entry.thinkingLevel;
+			} else if (entry.type === "thinkingLevelChange") {
+				thinkingLevel = entry.thinkingLevel;
+			}
+		}
+
+		return { messages, thinkingLevel: thinkingLevel as ThinkingLevel, model };
+	}
+
+	private extractMessages(entries: InMemoryEntry[]): AgentMessage[] {
+		const messages: AgentMessage[] = [];
+		for (const entry of entries) {
+			if (entry.type === "message") {
+				messages.push(entry.message);
+			} else if (entry.type === "customMessage") {
+				messages.push(
+					createCustomMessage(
+						entry.customType,
+						entry.content,
+						entry.display,
+						entry.details,
+						Date.now(),
+					),
+				);
+			}
+		}
+		return messages;
+	}
+}
+
+/**
+ * Creates a new in-memory {@link SessionManager} that stores all entries in
+ * memory without any filesystem persistence. Suitable for testing,
+ * programmatic/embedded usage, and consumers who manage their own persistence.
+ */
+export function createInMemorySessionManager(): SessionManager {
+	return new InMemorySessionManager();
+}

--- a/packages/otter-agent/src/session-managers/index.ts
+++ b/packages/otter-agent/src/session-managers/index.ts
@@ -1,0 +1,32 @@
+import type { SessionManager as ISessionManager } from "../interfaces/session-manager.js";
+import { createInMemorySessionManager } from "./in-memory-session-manager.js";
+
+export { createInMemorySessionManager } from "./in-memory-session-manager.js";
+
+/**
+ * Namespace providing factory methods for built-in {@link ISessionManager}
+ * implementations. The empty interface extension below enables TypeScript
+ * declaration merging so `SessionManager` is both a type (the full interface)
+ * and a value (the namespace with factory methods) in a single export.
+ *
+ * @example
+ * ```typescript
+ * import { SessionManager } from "@otter-agent/core";
+ * const sm: SessionManager = SessionManager.inMemory();
+ * ```
+ */
+// Empty interface extension enables declaration merging with the namespace below.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface SessionManager extends ISessionManager {}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace SessionManager {
+	/**
+	 * Creates an in-memory {@link ISessionManager} with no filesystem
+	 * persistence. Useful for testing, embedded usage, and consumers who
+	 * manage their own persistence.
+	 */
+	export function inMemory(): ISessionManager {
+		return createInMemorySessionManager();
+	}
+}


### PR DESCRIPTION
## Summary

Closes #16

- Adds optional `tokensBefore?: number` to `compact()` on the `SessionManager` interface, aligning with pi-coding-agent's API
- Implements `InMemorySessionManager` with an append-only discriminated union entry log
- `buildSessionContext()` handles compaction (latest wins, graceful fallback when `firstKeptEntryId` not found, post-compaction messages always included)
- Exports `createInMemorySessionManager()` factory and `SessionManager.inMemory()` static factory from the package root
- `SessionManager` is both a type (the interface) and a value (namespace with factory methods) via TypeScript declaration merging

## Test plan

- [x] 33 comprehensive unit tests covering all 8 interface methods and all compaction edge cases
- [x] `bun run test` — 188 pass, 0 fail
- [x] `bun run build` — clean
- [x] `bun run lint` — clean
- [x] Independent review by pi-coding-agent — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)