### PR TITLE
feat: add InMemoryAuthStorage implementation

### DIFF
--- a/packages/otter-agent/src/auth-storages/in-memory-auth-storage.test.ts
+++ b/packages/otter-agent/src/auth-storages/in-memory-auth-storage.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryAuthStorage } from "./in-memory-auth-storage.js";
+import { AuthStorage } from "./index.js";
+
+// ─── createInMemoryAuthStorage ────────────────────────────────────────────────
+
+describe("createInMemoryAuthStorage", () => {
+	test("returns the key for a known provider", async () => {
+		const auth = createInMemoryAuthStorage({ anthropic: "sk-ant-123" });
+		expect(await auth.getApiKey("anthropic")).toBe("sk-ant-123");
+	});
+
+	test("returns undefined for an unknown provider", async () => {
+		const auth = createInMemoryAuthStorage({ anthropic: "sk-ant-123" });
+		expect(await auth.getApiKey("openai")).toBeUndefined();
+	});
+
+	test("returns undefined for all providers when created with no keys", async () => {
+		const auth = createInMemoryAuthStorage();
+		expect(await auth.getApiKey("anthropic")).toBeUndefined();
+	});
+
+	test("supports multiple providers", async () => {
+		const auth = createInMemoryAuthStorage({
+			anthropic: "sk-ant-123",
+			openai: "sk-oai-456",
+		});
+		expect(await auth.getApiKey("anthropic")).toBe("sk-ant-123");
+		expect(await auth.getApiKey("openai")).toBe("sk-oai-456");
+	});
+
+	test("each call returns an independent instance", async () => {
+		const auth1 = createInMemoryAuthStorage({ anthropic: "key-1" });
+		const auth2 = createInMemoryAuthStorage({ anthropic: "key-2" });
+		expect(await auth1.getApiKey("anthropic")).toBe("key-1");
+		expect(await auth2.getApiKey("anthropic")).toBe("key-2");
+	});
+});
+
+// ─── AuthStorage.inMemory() factory ──────────────────────────────────────────
+
+describe("AuthStorage.inMemory()", () => {
+	test("returns a working AuthStorage instance", async () => {
+		const auth = AuthStorage.inMemory({ anthropic: "sk-ant-123" });
+		expect(await auth.getApiKey("anthropic")).toBe("sk-ant-123");
+	});
+
+	test("returns undefined for unknown provider", async () => {
+		const auth = AuthStorage.inMemory({ anthropic: "sk-ant-123" });
+		expect(await auth.getApiKey("openai")).toBeUndefined();
+	});
+
+	test("works with no arguments", async () => {
+		const auth = AuthStorage.inMemory();
+		expect(await auth.getApiKey("anthropic")).toBeUndefined();
+	});
+
+	test("each call returns an independent instance", async () => {
+		const auth1 = AuthStorage.inMemory({ anthropic: "key-1" });
+		const auth2 = AuthStorage.inMemory({ anthropic: "key-2" });
+		expect(await auth1.getApiKey("anthropic")).toBe("key-1");
+		expect(await auth2.getApiKey("anthropic")).toBe("key-2");
+	});
+
+	test("satisfies the AuthStorage type (type-level check via createInMemoryAuthStorage)", async () => {
+		const auth1 = AuthStorage.inMemory();
+		const auth2 = createInMemoryAuthStorage();
+		expect(typeof auth1.getApiKey).toBe("function");
+		expect(typeof auth2.getApiKey).toBe("function");
+	});
+});

--- a/packages/otter-agent/src/auth-storages/in-memory-auth-storage.ts
+++ b/packages/otter-agent/src/auth-storages/in-memory-auth-storage.ts
@@ -1,0 +1,25 @@
+import type { AuthStorage } from "../interfaces/auth-storage.js";
+
+class InMemoryAuthStorage implements AuthStorage {
+	private readonly keys: ReadonlyMap<string, string>;
+
+	constructor(keys: Record<string, string> = {}) {
+		this.keys = new Map(Object.entries(keys));
+	}
+
+	async getApiKey(provider: string): Promise<string | undefined> {
+		return this.keys.get(provider);
+	}
+}
+
+/**
+ * Creates a new read-only in-memory {@link AuthStorage} seeded with the
+ * provided provider-to-API-key map. Returns `undefined` for any provider
+ * not present in the initial map.
+ *
+ * @param keys - Optional map of provider identifier to API key
+ *   (e.g., `{ anthropic: "sk-ant-...", openai: "sk-..." }`).
+ */
+export function createInMemoryAuthStorage(keys?: Record<string, string>): AuthStorage {
+	return new InMemoryAuthStorage(keys);
+}

--- a/packages/otter-agent/src/auth-storages/index.ts
+++ b/packages/otter-agent/src/auth-storages/index.ts
@@ -1,0 +1,35 @@
+import type { AuthStorage as IAuthStorage } from "../interfaces/auth-storage.js";
+import { createInMemoryAuthStorage } from "./in-memory-auth-storage.js";
+
+export { createInMemoryAuthStorage } from "./in-memory-auth-storage.js";
+
+/**
+ * Namespace providing factory methods for built-in {@link IAuthStorage}
+ * implementations. The empty interface extension below enables TypeScript
+ * declaration merging so `AuthStorage` is both a type (the full interface)
+ * and a value (the namespace with factory methods) in a single export.
+ *
+ * @example
+ * ```typescript
+ * import { AuthStorage } from "@otter-agent/core";
+ * const auth: AuthStorage = AuthStorage.inMemory({ anthropic: "sk-ant-..." });
+ * ```
+ */
+// Empty interface extension enables declaration merging with the namespace below.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface AuthStorage extends IAuthStorage {}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace AuthStorage {
+	/**
+	 * Creates a read-only in-memory {@link IAuthStorage} seeded with the
+	 * provided provider-to-API-key map. Useful for testing and embedded usage
+	 * where credentials are known at construction time.
+	 *
+	 * @param keys - Optional map of provider identifier to API key
+	 *   (e.g., `{ anthropic: "sk-ant-...", openai: "sk-..." }`).
+	 */
+	export function inMemory(keys?: Record<string, string>): IAuthStorage {
+		return createInMemoryAuthStorage(keys);
+	}
+}

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -1,7 +1,6 @@
 // OtterAgent interfaces
 export type {
 	AgentEnvironment,
-	AuthStorage,
 	EntryId,
 	ReadonlySessionManager,
 	SessionContext,
@@ -9,6 +8,11 @@ export type {
 	UIProvider,
 } from "./interfaces/index.js";
 export { noOpUIProvider } from "./interfaces/ui.js";
+
+// Built-in AuthStorage implementations.
+// AuthStorage is exported as both a type (the interface) and a value
+// (namespace with factory methods) via declaration merging in auth-storages/index.ts.
+export { AuthStorage, createInMemoryAuthStorage } from "./auth-storages/index.js";
 
 // Built-in SessionManager implementations.
 // SessionManager is exported as both a type (the interface) and a value


### PR DESCRIPTION
Closes #27

## Summary

- Adds `InMemoryAuthStorage` — a read-only in-memory implementation of `AuthStorage` seeded from an optional `provider → apiKey` map
- Follows the declaration-merging pattern established by `SessionManager`: `AuthStorage` is exported as both a type and a namespace with factory methods
- Both `AuthStorage.inMemory(map?)` and `createInMemoryAuthStorage(map?)` are exported from the public API

## Changes

- `src/auth-storages/in-memory-auth-storage.ts` — private class + `createInMemoryAuthStorage()` factory
- `src/auth-storages/index.ts` — declaration merging: `AuthStorage` type + namespace
- `src/auth-storages/in-memory-auth-storage.test.ts` — 10 tests covering both API surfaces
- `src/index.ts` — re-exports `AuthStorage` and `createInMemoryAuthStorage` from the new module

## Test plan

- [x] `AuthStorage.inMemory({ anthropic: "sk-..." })` returns the key for a known provider
- [x] Returns `undefined` for unknown providers
- [x] Works with no arguments (empty store)
- [x] Each call returns an independent instance
- [x] All 202 tests pass, build and lint clean (verified via pi-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)