### PR TITLE
feat: expose AgentEnvironment to extensions via ExtensionContext

### DIFF
--- a/packages/otter-agent/src/extensions/context.ts
+++ b/packages/otter-agent/src/extensions/context.ts
@@ -2,6 +2,7 @@
  * Context objects passed to extension event handlers and command handlers.
  */
 import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ReadonlyAgentEnvironment } from "../interfaces/agent-environment.js";
 import type { ReadonlySessionManager } from "../interfaces/session-manager.js";
 import type { UIProvider } from "../interfaces/ui-provider.js";
 
@@ -37,6 +38,9 @@ export interface ExtensionContext {
 
 	/** Session manager (read-only). */
 	sessionManager: ReadonlySessionManager;
+
+	/** The agent environment (read-only). */
+	agentEnvironment: ReadonlyAgentEnvironment;
 
 	/** Current model, if set. */
 	model: Model<Api> | undefined;

--- a/packages/otter-agent/src/extensions/extension-runner.test.ts
+++ b/packages/otter-agent/src/extensions/extension-runner.test.ts
@@ -26,6 +26,10 @@ function createMockActions(): ExtensionRunnerActions {
 		appendEntry: mock(() => {}),
 		setLabel: mock(() => {}),
 		getSessionManager: mock(() => ({})),
+		getAgentEnvironment: mock(() => ({
+			getSystemMessageAppend: () => undefined,
+			getTools: () => [],
+		})),
 		getModel: mock(() => undefined),
 		isIdle: mock(() => true),
 		getSignal: mock(() => undefined),
@@ -816,6 +820,86 @@ describe("ExtensionRunner", () => {
 			await runner.emit({ type: "session_start" });
 			expect(listener1).toHaveBeenCalledTimes(1); // not called again
 			expect(listener2).toHaveBeenCalledTimes(2); // still called
+		});
+	});
+
+	// ─── ExtensionContext ────────────────────────────────────────
+
+	describe("ExtensionContext", () => {
+		test("agentEnvironment is exposed to event handlers", async () => {
+			const mockActions = createMockActions();
+			mockActions.getAgentEnvironment = mock(() => ({
+				getSystemMessageAppend: () => "test-append",
+				getTools: () => [],
+			}));
+
+			const runner = new ExtensionRunner();
+			runner.bindActions(mockActions);
+
+			let capturedEnv: unknown;
+			await runner.loadExtensions([
+				(api) =>
+					api.on("session_start", (_event, ctx) => {
+						capturedEnv = ctx.agentEnvironment;
+					}),
+			]);
+
+			await runner.emit({ type: "session_start" });
+
+			expect(capturedEnv).toBeDefined();
+			expect(
+				(capturedEnv as { getSystemMessageAppend(): string | undefined }).getSystemMessageAppend(),
+			).toBe("test-append");
+		});
+
+		test("agentEnvironment is the same object returned by getAgentEnvironment", async () => {
+			const mockActions = createMockActions();
+			const expectedEnv = {
+				getSystemMessageAppend: () => undefined,
+				getTools: () => [],
+			};
+			mockActions.getAgentEnvironment = mock(() => expectedEnv);
+
+			const runner = new ExtensionRunner();
+			runner.bindActions(mockActions);
+
+			let capturedEnv: unknown;
+			await runner.loadExtensions([
+				(api) =>
+					api.on("session_start", (_event, ctx) => {
+						capturedEnv = ctx.agentEnvironment;
+					}),
+			]);
+
+			await runner.emit({ type: "session_start" });
+
+			expect(capturedEnv).toBe(expectedEnv);
+		});
+
+		test("agentEnvironment is exposed in command context", async () => {
+			const mockActions = createMockActions();
+			const expectedEnv = {
+				getSystemMessageAppend: () => "cmd-context",
+				getTools: () => [],
+			};
+			mockActions.getAgentEnvironment = mock(() => expectedEnv);
+
+			const runner = new ExtensionRunner();
+			runner.bindActions(mockActions);
+
+			let capturedEnv: unknown;
+			await runner.loadExtensions([
+				(api) =>
+					api.registerCommand("check-env", {
+						handler: async (_args, ctx) => {
+							capturedEnv = ctx.agentEnvironment;
+						},
+					}),
+			]);
+
+			await runner.executeCommand("check-env", "");
+
+			expect(capturedEnv).toBe(expectedEnv);
 		});
 	});
 

--- a/packages/otter-agent/src/extensions/extension-runner.ts
+++ b/packages/otter-agent/src/extensions/extension-runner.ts
@@ -6,6 +6,7 @@
  */
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { Api, ImageContent, Model, TextContent } from "@mariozechner/pi-ai";
+import type { ReadonlyAgentEnvironment } from "../interfaces/agent-environment.js";
 import type { EntryId, ReadonlySessionManager } from "../interfaces/session-manager.js";
 import type { ToolDefinition } from "../interfaces/tool-definition.js";
 import type { UIProvider } from "../interfaces/ui-provider.js";
@@ -70,6 +71,7 @@ export interface ExtensionRunnerActions {
 	appendEntry: (customType: string, data?: unknown) => void;
 	setLabel: (entryId: EntryId, label: string | undefined) => void;
 	getSessionManager: () => ReadonlySessionManager;
+	getAgentEnvironment: () => ReadonlyAgentEnvironment;
 	getModel: () => Model<Api> | undefined;
 	isIdle: () => boolean;
 	getSignal: () => AbortSignal | undefined;
@@ -403,6 +405,7 @@ export class ExtensionRunner {
 			ui: this._uiProvider,
 			hasUI: this._uiProvider !== noOpUIProvider,
 			sessionManager: actions.getSessionManager(),
+			agentEnvironment: actions.getAgentEnvironment(),
 			model: actions.getModel(),
 			isIdle: actions.isIdle,
 			signal: actions.getSignal(),

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -1,6 +1,7 @@
 // OtterAgent interfaces
 export type {
 	EntryId,
+	ReadonlyAgentEnvironment,
 	ReadonlySessionManager,
 	SessionContext,
 	ToolDefinition,

--- a/packages/otter-agent/src/interfaces/agent-environment.ts
+++ b/packages/otter-agent/src/interfaces/agent-environment.ts
@@ -32,3 +32,18 @@ export interface AgentEnvironment {
 	 */
 	getTools(): ToolDefinition[];
 }
+
+/**
+ * A read-only view of AgentEnvironment suitable for exposing to extensions.
+ *
+ * Extensions can inspect the environment's system message contribution and
+ * the tools it provides, but cannot reconfigure the environment itself.
+ *
+ * Concrete environment instances (e.g. JustBashAgentEnvironment) can be
+ * narrowed from this type using capability-specific type guards, allowing
+ * extensions to opt in to richer environment APIs when available.
+ */
+export type ReadonlyAgentEnvironment = Pick<
+	AgentEnvironment,
+	"getSystemMessageAppend" | "getTools"
+>;

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -1,4 +1,4 @@
-export type { AgentEnvironment } from "./agent-environment.js";
+export type { AgentEnvironment, ReadonlyAgentEnvironment } from "./agent-environment.js";
 export type { AuthStorage } from "./auth-storage.js";
 export type {
 	SessionContext,

--- a/packages/otter-agent/src/session/agent-session.test.ts
+++ b/packages/otter-agent/src/session/agent-session.test.ts
@@ -560,6 +560,33 @@ describe("AgentSession", () => {
 			await session.dispose();
 		});
 
+		test("agentEnvironment is exposed to extensions via context", async () => {
+			const environment = createMockEnvironment({ systemAppend: "env-context-test" });
+
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment,
+				systemPrompt: "Prompt.",
+			});
+
+			let capturedEnv: unknown;
+			await session.loadExtensions([
+				(api) =>
+					api.on("session_start", (_event, ctx) => {
+						capturedEnv = ctx.agentEnvironment;
+					}),
+			]);
+
+			expect(capturedEnv).toBeDefined();
+			expect(capturedEnv).toBe(environment);
+			expect(
+				(capturedEnv as { getSystemMessageAppend(): string | undefined }).getSystemMessageAppend(),
+			).toBe("env-context-test");
+
+			await session.dispose();
+		});
+
 		test("extensionRunner is accessible", async () => {
 			const session = new AgentSession({
 				sessionManager: createMockSessionManager(),

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -574,6 +574,7 @@ export class AgentSession {
 				}
 			},
 			getSessionManager: () => this.sessionManager,
+			getAgentEnvironment: () => this._environment,
 			getModel: () => this.agent.state.model,
 			isIdle: () => !this.agent.state.isStreaming,
 			getSignal: () => this.agent.signal,


### PR DESCRIPTION
Closes #32

## Summary

- Adds `ReadonlyAgentEnvironment` as `Pick<AgentEnvironment, "getSystemMessageAppend" | "getTools">`, matching the existing `ReadonlySessionManager` pattern
- Exposes it as `ctx.agentEnvironment` on `ExtensionContext`, available in all extension event handlers and command handlers
- The runtime value is the actual environment instance, enabling type narrowing via user-defined type guards for future capability interfaces (e.g. `isBashCommandRegistrar`)
- Wired through `ExtensionRunnerActions.getAgentEnvironment` → `AgentSession._buildRunnerActions()` → `_buildExtensionContext()`
- `ExtensionCommandContext` inherits the field for free via the existing spread

## Test plan

- [ ] `ctx.agentEnvironment` is present in extension event handlers
- [ ] `ctx.agentEnvironment` is the same object reference as the environment passed to `AgentSession` (runtime identity confirmed)
- [ ] `ctx.agentEnvironment` is present in command context
- [ ] All 242 existing tests pass
- [ ] Build and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)