### PR TITLE
refactor: remove ReadonlyAgentEnvironment in favour of AgentEnvironment

### DIFF
--- a/packages/otter-agent/src/extensions/context.ts
+++ b/packages/otter-agent/src/extensions/context.ts
@@ -2,7 +2,7 @@
  * Context objects passed to extension event handlers and command handlers.
  */
 import type { Api, Model } from "@mariozechner/pi-ai";
-import type { ReadonlyAgentEnvironment } from "../interfaces/agent-environment.js";
+import type { AgentEnvironment } from "../interfaces/agent-environment.js";
 import type { ReadonlySessionManager } from "../interfaces/session-manager.js";
 import type { UIProvider } from "../interfaces/ui-provider.js";
 
@@ -39,8 +39,20 @@ export interface ExtensionContext {
 	/** Session manager (read-only). */
 	sessionManager: ReadonlySessionManager;
 
-	/** The agent environment (read-only). */
-	agentEnvironment: ReadonlyAgentEnvironment;
+	/**
+	 * The agent environment.
+	 *
+	 * Use capability-specific type guards to access richer APIs on concrete
+	 * implementations when you need more than the base {@link AgentEnvironment}
+	 * interface. For example:
+	 *
+	 * ```ts
+	 * if (isJustBashAgentEnvironment(ctx.agentEnvironment)) {
+	 *   // access JustBashAgentEnvironment-specific methods here
+	 * }
+	 * ```
+	 */
+	agentEnvironment: AgentEnvironment;
 
 	/** Current model, if set. */
 	model: Model<Api> | undefined;

--- a/packages/otter-agent/src/extensions/extension-runner.ts
+++ b/packages/otter-agent/src/extensions/extension-runner.ts
@@ -6,7 +6,7 @@
  */
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { Api, ImageContent, Model, TextContent } from "@mariozechner/pi-ai";
-import type { ReadonlyAgentEnvironment } from "../interfaces/agent-environment.js";
+import type { AgentEnvironment } from "../interfaces/agent-environment.js";
 import type { EntryId, ReadonlySessionManager } from "../interfaces/session-manager.js";
 import type { ToolDefinition } from "../interfaces/tool-definition.js";
 import type { UIProvider } from "../interfaces/ui-provider.js";
@@ -71,7 +71,7 @@ export interface ExtensionRunnerActions {
 	appendEntry: (customType: string, data?: unknown) => void;
 	setLabel: (entryId: EntryId, label: string | undefined) => void;
 	getSessionManager: () => ReadonlySessionManager;
-	getAgentEnvironment: () => ReadonlyAgentEnvironment;
+	getAgentEnvironment: () => AgentEnvironment;
 	getModel: () => Model<Api> | undefined;
 	isIdle: () => boolean;
 	getSignal: () => AbortSignal | undefined;

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -1,7 +1,6 @@
 // OtterAgent interfaces
 export type {
 	EntryId,
-	ReadonlyAgentEnvironment,
 	ReadonlySessionManager,
 	SessionContext,
 	ToolDefinition,

--- a/packages/otter-agent/src/interfaces/agent-environment.ts
+++ b/packages/otter-agent/src/interfaces/agent-environment.ts
@@ -9,6 +9,15 @@ import type { ToolDefinition } from "./tool-definition.js";
  *
  * An agent has exactly one environment. Both methods are called once at
  * startup — they are not dynamic.
+ *
+ * Extensions receive an `AgentEnvironment` and should use capability-specific
+ * type guards to access richer APIs on concrete implementations. For example:
+ *
+ * ```ts
+ * if (isJustBashAgentEnvironment(ctx.agentEnvironment)) {
+ *   // access JustBashAgentEnvironment-specific methods here
+ * }
+ * ```
  */
 export interface AgentEnvironment {
 	/**
@@ -32,18 +41,3 @@ export interface AgentEnvironment {
 	 */
 	getTools(): ToolDefinition[];
 }
-
-/**
- * A read-only view of AgentEnvironment suitable for exposing to extensions.
- *
- * Extensions can inspect the environment's system message contribution and
- * the tools it provides, but cannot reconfigure the environment itself.
- *
- * Concrete environment instances (e.g. JustBashAgentEnvironment) can be
- * narrowed from this type using capability-specific type guards, allowing
- * extensions to opt in to richer environment APIs when available.
- */
-export type ReadonlyAgentEnvironment = Pick<
-	AgentEnvironment,
-	"getSystemMessageAppend" | "getTools"
->;

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -1,4 +1,4 @@
-export type { AgentEnvironment, ReadonlyAgentEnvironment } from "./agent-environment.js";
+export type { AgentEnvironment } from "./agent-environment.js";
 export type { AuthStorage } from "./auth-storage.js";
 export type {
 	SessionContext,


### PR DESCRIPTION
## Summary

- Removes the redundant `ReadonlyAgentEnvironment` type, which was a `Pick` over all methods of `AgentEnvironment` making the two types structurally identical
- Replaces all 7 usages with `AgentEnvironment` directly across `context.ts`, `extension-runner.ts`, `interfaces/index.ts`, and the root `index.ts`
- Moves the type guard documentation onto the `AgentEnvironment` interface JSDoc and the `ExtensionContext.agentEnvironment` property so extension authors know to use type guards when accessing richer concrete APIs

Closes #34

## Test plan

- [x] All 242 tests pass
- [x] Build clean
- [x] Lint clean
- [x] Independent pi-review passed with no concerns

🤖 Generated with [Claude Code](https://claude.com/claude-code)