### PR TITLE
feat: add tools option to JustBashAgentEnvironmentOptions

### DIFF
--- a/packages/otter-agent/src/environments/agent-environment.ts
+++ b/packages/otter-agent/src/environments/agent-environment.ts
@@ -2,9 +2,10 @@ import type { AgentEnvironment as IAgentEnvironment } from "../interfaces/agent-
 import {
 	JustBashAgentEnvironment,
 	type JustBashAgentEnvironmentOptions,
+	type JustBashToolName,
 } from "./just-bash/just-bash-agent-environment.js";
 
-export { JustBashAgentEnvironment, type JustBashAgentEnvironmentOptions };
+export { JustBashAgentEnvironment, type JustBashAgentEnvironmentOptions, type JustBashToolName };
 
 /**
  * Namespace providing factory methods for built-in {@link IAgentEnvironment}

--- a/packages/otter-agent/src/environments/index.ts
+++ b/packages/otter-agent/src/environments/index.ts
@@ -2,4 +2,5 @@ export {
 	AgentEnvironment,
 	JustBashAgentEnvironment,
 	type JustBashAgentEnvironmentOptions,
+	type JustBashToolName,
 } from "./agent-environment.js";

--- a/packages/otter-agent/src/environments/just-bash/just-bash-agent-environment.test.ts
+++ b/packages/otter-agent/src/environments/just-bash/just-bash-agent-environment.test.ts
@@ -39,6 +39,23 @@ describe("JustBashAgentEnvironment", () => {
 		expect(names).toEqual(["bash", "read", "write", "edit"]);
 	});
 
+	test("getTools() returns only specified tools when tools option is provided", () => {
+		const env = makeEnv({ tools: ["bash", "read"] });
+		const names = env.getTools().map((t) => t.name);
+		expect(names).toEqual(["bash", "read"]);
+	});
+
+	test("getTools() returns empty array when tools option is empty", () => {
+		const env = makeEnv({ tools: [] });
+		expect(env.getTools()).toEqual([]);
+	});
+
+	test("getTools() preserves order from tools option", () => {
+		const env = makeEnv({ tools: ["edit", "bash"] });
+		const names = env.getTools().map((t) => t.name);
+		expect(names).toEqual(["edit", "bash"]);
+	});
+
 	test("getSystemMessageAppend() returns a non-empty string describing the environment", () => {
 		const env = makeEnv({ cwd: "/workspace" });
 		const append = env.getSystemMessageAppend();

--- a/packages/otter-agent/src/environments/just-bash/just-bash-agent-environment.ts
+++ b/packages/otter-agent/src/environments/just-bash/just-bash-agent-environment.ts
@@ -10,6 +10,9 @@ import { createWriteToolDefinition } from "./tools/write.js";
 /** Execution limits configuration for the just-bash interpreter. */
 type ExecutionLimits = NonNullable<BashOptions["executionLimits"]>;
 
+/** Names of the tools exposed by {@link JustBashAgentEnvironment}. */
+export type JustBashToolName = "bash" | "read" | "write" | "edit";
+
 export interface JustBashAgentEnvironmentOptions {
 	/** Initial files to seed the virtual filesystem with. */
 	files?: InitialFiles;
@@ -23,6 +26,17 @@ export interface JustBashAgentEnvironmentOptions {
 	network?: NetworkConfig;
 	/** Allowlist of built-in command names. All built-ins enabled when omitted. */
 	commands?: CommandName[];
+	/**
+	 * Tools to expose to the agent. When omitted, all four tools are included.
+	 * Pass an explicit array to restrict which tools are available.
+	 *
+	 * @example
+	 * ```ts
+	 * // Only expose bash and read — no write or edit.
+	 * new JustBashAgentEnvironment({ tools: ["bash", "read"] });
+	 * ```
+	 */
+	tools?: JustBashToolName[];
 }
 
 /**
@@ -51,12 +65,15 @@ export class JustBashAgentEnvironment implements AgentEnvironment {
 			commands: options.commands,
 		});
 
-		this._tools = [
-			createBashToolDefinition(this._bash),
-			createReadToolDefinition(this._bash, cwd),
-			createWriteToolDefinition(this._bash, cwd),
-			createEditToolDefinition(this._bash, cwd),
-		];
+		const allTools: Record<JustBashToolName, ToolDefinition> = {
+			bash: createBashToolDefinition(this._bash),
+			read: createReadToolDefinition(this._bash, cwd),
+			write: createWriteToolDefinition(this._bash, cwd),
+			edit: createEditToolDefinition(this._bash, cwd),
+		};
+
+		const enabled = options.tools ?? (["bash", "read", "write", "edit"] as JustBashToolName[]);
+		this._tools = enabled.map((name) => allTools[name]);
 	}
 
 	getSystemMessageAppend(): string {

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -14,6 +14,7 @@ export {
 	AgentEnvironment,
 	JustBashAgentEnvironment,
 	type JustBashAgentEnvironmentOptions,
+	type JustBashToolName,
 } from "./environments/index.js";
 export { noOpUIProvider } from "./interfaces/ui.js";
 


### PR DESCRIPTION
## Summary

- Adds `JustBashToolName = "bash" | "read" | "write" | "edit"` type alias
- Adds optional `tools?: JustBashToolName[]` to `JustBashAgentEnvironmentOptions` — when omitted all four tools are included (preserving existing behaviour)
- Exports `JustBashToolName` from all barrel files (`environments/agent-environment.ts`, `environments/index.ts`, `src/index.ts`)

Closes #31

## Test plan

- [ ] Default behaviour (no `tools` option) returns all four tools
- [ ] Subset selection (e.g. `["bash", "read"]`) returns only those tools
- [ ] Empty array `[]` returns no tools
- [ ] Order of tools in the array is preserved in `getTools()` output
- [ ] Build passes (`bun run build`)
- [ ] Lint passes (`bun run lint`)
- [ ] All 245 tests pass (`bun run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)