### PR TITLE
chore: set up .pi folder with skills and sync CLAUDE.md/AGENTS.md

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pi-review
+name: code-review
 description: Run an independent code review using pi-coding-agent. Use after completing an implementation to get a second opinion before pushing. Pass the issue number or a short description of what was implemented.
 argument-hint: "[issue-number or description]"
 ---

--- a/.claude/skills/interface-implementation/SKILL.md
+++ b/.claude/skills/interface-implementation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: add-implementation
+name: interface-implementation
 description: Add a built-in implementation of an interface in OtterAgent. Use when implementing a new built-in for an existing interface (e.g. a new SessionManager, AuthStorage, or UIProvider).
 ---
 

--- a/.pi/prompts/overview.md
+++ b/.pi/prompts/overview.md
@@ -1,0 +1,5 @@
+---
+description: Overview of the repository, core components, and open GitHub issues
+---
+
+Please give me an overview of this repository, the core components and how they wire together as well as an overview of the open github issues.

--- a/.pi/skills/code-review/SKILL.md
+++ b/.pi/skills/code-review/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: code-review
+description: Run an independent code review using pi-coding-agent. Use after completing an implementation to get a second opinion before pushing. Pass the issue number or a short description of what was implemented.
+argument-hint: "[issue-number or description]"
+---
+
+Run an independent code review of the current implementation using the pi-coding-agent CLI.
+
+## What to do
+
+1. Identify the issue number:
+   - If `$ARGUMENTS` is a number, use it directly as the issue number.
+   - If `$ARGUMENTS` is a description, find the matching issue: `gh issue list --repo BowerJames/OtterAgent --search "$ARGUMENTS" --json number,title --limit 5`
+
+2. Identify the files changed in the most recent commit(s): `git diff HEAD~1..HEAD --name-only`
+
+3. Build a review prompt (see structure below). The prompt must **include the issue number** so pi can look it up itself — do NOT embed the issue contents in the prompt.
+
+4. Call the pi-coding-agent:
+   ```
+   pi --model glm-5-turbo -p "<your prompt>"
+   ```
+
+5. Report the full output of the review back to the user, then ask how to proceed.
+
+## Review prompt structure
+
+Use this structure for the prompt passed to pi:
+
+```
+You are doing an independent code review of a recently committed implementation
+for issue #<ISSUE_NUMBER> in the OtterAgent project (located at /root/Projects/OtterAgent).
+
+## Step 0 — Read the GitHub issue
+
+Start by reading the full GitHub issue using the gh CLI. You MUST do this before anything else:
+
+1. **Title and description**: `gh issue view <ISSUE_NUMBER> --repo BowerJames/OtterAgent --json title,body`
+2. **Comments**: `gh issue view <ISSUE_NUMBER> --repo BowerJames/OtterAgent --comments`
+
+Use the title, description, and all comments to fully understand the requirements, context, and any prior discussion before reviewing the code.
+
+## Step 1 — Accuracy & Completeness
+
+Verify that the implementation addresses every requirement mentioned in the issue and its comments.
+
+## Step 2 — Code Quality
+
+Run the linter and report any issues:
+- Run: cd /root/Projects/OtterAgent && bun run lint
+
+## Step 3 — Tests
+
+Run the full test suite and report results:
+- Run: cd /root/Projects/OtterAgent && bun run test
+- Assess whether the test coverage is appropriate for the change
+
+## Step 4 — Build
+
+Verify the project builds cleanly:
+- Run: cd /root/Projects/OtterAgent && bun run build
+
+## Step 5 — Post review as a GitHub comment
+
+Before you finish, post your complete review as a comment on the GitHub issue:
+
+- Run: `gh issue comment <ISSUE_NUMBER> --repo BowerJames/OtterAgent --body "<your full review>"`
+
+The comment should include all your findings — issues, gaps, concerns, and anything that looks correct.
+
+Report all findings in full — any issues, gaps, or concerns, as well as confirmation of anything that looks correct.
+```
+
+## Notes
+
+- Use `glm-5-turbo` as the model — it has the right balance of capability and speed for reviews.
+- Run the review before pushing to remote. If the reviewer finds issues, fix them and re-run the review to confirm before pushing.
+- If the reviewer raises a concern you disagree with, discuss it with the user before deciding whether to act on it.

--- a/.pi/skills/interface-implementation/SKILL.md
+++ b/.pi/skills/interface-implementation/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: interface-implementation
+description: Add a built-in implementation of an interface in OtterAgent. Use when implementing a new built-in for an existing interface (e.g. a new SessionManager, AuthStorage, or UIProvider).
+---
+
+Follow this pattern exactly when adding a built-in implementation of an OtterAgent interface.
+
+## Folder Structure
+
+Implementations of a given interface live together in a dedicated folder:
+
+```
+src/
+  <interface-name-plural>/         e.g. session-managers/, auth-storages/
+    <impl-name>.ts                 e.g. in-memory-session-manager.ts
+    <impl-name>.test.ts            e.g. in-memory-session-manager.test.ts
+    index.ts                       namespace + re-exports for the whole folder
+```
+
+If the folder already exists (other implementations are present), add the new `.ts` and `.test.ts` files alongside them and add the new factory to the existing `index.ts` namespace.
+
+## 1. Implementation File (`<impl-name>.ts`)
+
+- Define the implementation as a **class that is NOT exported**.
+- Export only a `createXxx(): InterfaceType` factory function.
+- The class must explicitly `implements` the interface so TypeScript enforces completeness.
+
+```typescript
+// src/session-managers/in-memory-session-manager.ts
+
+import type { SessionManager } from "../interfaces/session-manager.js";
+
+class InMemorySessionManager implements SessionManager {
+  // ... implementation
+}
+
+/**
+ * Creates an in-memory {@link SessionManager} with no filesystem persistence.
+ */
+export function createInMemorySessionManager(): SessionManager {
+  return new InMemorySessionManager();
+}
+```
+
+## 2. Namespace / Index File (`index.ts`)
+
+This file does two things:
+1. Re-exports the factory function(s) from implementation files.
+2. Declares a **namespace** whose name matches the interface, merged with an empty interface extension. This makes the interface name serve as both a **type** and a **value** (the namespace) from a single import.
+
+```typescript
+// src/session-managers/index.ts
+
+import type { SessionManager as ISessionManager } from "../interfaces/session-manager.js";
+import { createInMemorySessionManager } from "./in-memory-session-manager.js";
+
+export { createInMemorySessionManager } from "./in-memory-session-manager.js";
+
+// Empty interface extension enables TypeScript declaration merging with the
+// namespace below. Consumers get SessionManager as both a type and a value.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface SessionManager extends ISessionManager {}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace SessionManager {
+  export function inMemory(): ISessionManager {
+    return createInMemorySessionManager();
+  }
+
+  // Add new built-ins here as additional methods on the same namespace.
+  // export function sqlite(path: string): ISessionManager { ... }
+}
+```
+
+**Why the empty interface?** TypeScript does not allow merging a namespace with a plain type alias or an imported interface re-export. The empty `interface Xxx extends IXxx {}` declares a *local* interface that TypeScript can merge with the namespace in the same file.
+
+## 3. Root Barrel (`src/index.ts`)
+
+Export the namespace from the implementations index. A single `export { Xxx }` is enough — TypeScript carries both the type (via the merged interface) and the value (the namespace) through one export.
+
+**Do NOT also add a separate `export type { Xxx }` for the same name** — this causes `TS2300: Duplicate identifier`.
+
+```typescript
+// src/index.ts
+
+// Remove the interface from the plain type export block if it was there:
+export type {
+  AgentEnvironment,
+  AuthStorage,
+  // SessionManager,   ← moved to session-managers export below
+  ToolDefinition,
+  UIProvider,
+} from "./interfaces/index.js";
+
+// Add the namespace export — carries both the type and the factory value:
+export { SessionManager } from "./session-managers/index.js";
+```
+
+If the interface was previously exported as `export type { Xxx }` from `interfaces/index.js`, remove it from that block and replace it with the single `export { Xxx }` from the implementations folder.
+
+## 4. Consumer Usage
+
+After wiring, consumers get a clean API with a single import:
+
+```typescript
+import { SessionManager } from "@otter-agent/core";
+
+// As a type:
+function accepts(sm: SessionManager) { ... }
+
+// As a factory:
+const sm = SessionManager.inMemory();
+```
+
+## 5. Tests
+
+Place tests in `<impl-name>.test.ts` alongside the implementation. Tests should be comprehensive and cover:
+- Every interface method: returns a unique `EntryId`, correct data stored/excluded
+- `buildSessionContext()` (or equivalent read method): correct output for all scenarios
+- Edge cases specific to the implementation
+- The namespace factory method (e.g. `SessionManager.inMemory()`) produces a working, independent instance
+
+## Reference Implementation
+
+See `src/session-managers/` for the canonical worked example:
+- `in-memory-session-manager.ts` — class + factory
+- `index.ts` — namespace merging
+- `in-memory-session-manager.test.ts` — 33 tests covering all interface methods and edge cases

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,16 @@ Format all files:
 bun run format
 ```
 
+## Code Review
+
+Before pushing to `main` or opening a pull request when completing a GitHub issue, an independent review must be run using the **code-review** skill:
+
+```
+/skill:code-review <issue-number>
+```
+
+Review the findings with the user before proceeding. If the reviewer raises issues, fix them and re-run the review to confirm before pushing.
+
 ## Conventions
 
 - **ESM-only** — all packages use `"type": "module"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,13 +66,9 @@ bun run format
 
 ## Code Review
 
-Before pushing to `main` or opening a pull request when completing a GitHub issue, an independent review must be run using the pi-coding-agent. Use the `/pi-review` skill:
+Before pushing to `main` or opening a pull request when completing a GitHub issue, an independent review must be run using the **code-review** skill.
 
-```
-/pi-review <issue-number>
-```
-
-This calls `pi --model glm-5-turbo` with a structured prompt covering accuracy, completeness, lint, tests, and build. Review the findings with the user before proceeding. If the reviewer raises issues, fix them and re-run the review to confirm before pushing.
+Review the findings with the user before proceeding. If the reviewer raises issues, fix them and re-run the review to confirm before pushing.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

- Set up `.pi/` project folder for pi-coding-agent with skills and prompts
- Add `code-review` and `interface-implementation` skills to both `.pi/skills/` and `.claude/skills/`
- Rename `.claude/skills/pi-review` → `code-review` and `add-implementation` → `interface-implementation`
- Add Code Review section to `AGENTS.md`
- Update `CLAUDE.md` Code Review section with tool-agnostic wording so both files stay in sync

## Details

- `.pi/prompts/overview.md` — `/overview` prompt template for repository overviews
- `.pi/skills/code-review/` — independent code review skill using pi-coding-agent
- `.pi/skills/interface-implementation/` — skill for adding built-in interface implementations
- Both `AGENTS.md` and `CLAUDE.md` now reference "the **code-review** skill" without tool-specific invocation syntax