### PR TITLE
feat: add lightweight mode extension for project-specific agent modes

### DIFF
--- a/.pi/extensions/mode/index.ts
+++ b/.pi/extensions/mode/index.ts
@@ -101,15 +101,15 @@ export default function modeExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_start", async (_event, ctx) => {
 		const entries = ctx.sessionManager.getEntries();
-		const modeEntry = entries
-			.filter(
-				(e: { type: string; customType?: string }) =>
-					e.type === "custom" && e.customType === "mode",
-			)
-			.pop() as { data?: { mode: string | null } } | undefined;
-
-		if (modeEntry?.data) {
-			activeMode = modeEntry.data.mode;
+		for (let i = entries.length - 1; i >= 0; i--) {
+			const entry = entries[i];
+			if (entry.type === "custom" && "customType" in entry && entry.customType === "mode") {
+				const mode = entry.data?.mode;
+				if (typeof mode === "string" && mode in MODES) {
+					activeMode = mode;
+				}
+				break;
+			}
 		}
 
 		updateStatus(ctx);


### PR DESCRIPTION
## Summary

Closes #42

Adds a project-local pi extension (`.pi/extensions/mode/index.ts`) providing a unified, mutually exclusive mode system. The initial mode is **plan mode**, which appends a planning instruction suffix to every user prompt.

## What changed

- **New file:** `.pi/extensions/mode/index.ts`

## Commands

| Command | Description |
|---------|-------------|
| `/mode plan` | Activate plan mode (footer shows "📋 plan", planning suffix appended to every prompt) |
| `/mode plan` | Toggle off if already active |
| `/mode` | Clear any active mode |
| `/plan` | Shorthand for `/mode plan` |

## Design decisions

- **Input transform** over `before_agent_start` message injection — the suffix never appears in session history, so toggling modes is completely clean
- **No tool restriction** — purely prompt-based guidance, all tools remain available
- **Mutually exclusive** — only one mode active at a time, activating a new mode replaces the current one
- **Persistence** — mode state restored on session resume/reload via `pi.appendEntry`
- **Registry validation** — stale persisted mode names are silently ignored if a mode is later removed
- **No unit tests** — `.pi/` extensions run inside pi's runtime and cannot be unit-tested with the project's test suite

## Review

Two rounds of independent code review completed (see [issue #42 comments](https://github.com/BowerJames/OtterAgent/issues/42)). All findings addressed.

## Acceptance criteria

- [x] `/mode plan` activates plan mode, footer shows "📋 plan"
- [x] `/plan` works as shorthand for `/mode plan`
- [x] Every user prompt gets the planning suffix appended
- [x] Extension-injected messages are not transformed
- [x] `/mode plan` again toggles plan mode off
- [x] `/mode` (no args) clears the mode
- [x] `/mode unknown` shows an error notification
- [x] Activating a different mode while one is active replaces it (no compounding)
- [x] Mode persists across session resume and reload
- [x] No tool restriction — bash and all tools remain available