### PR TITLE
feat: add @otter-agent/cli package with RPC mode (#47)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,17 @@
         "@mariozechner/pi-coding-agent": "^0.64.0",
       },
     },
+    "packages/otter-agent-cli": {
+      "name": "@otter-agent/cli",
+      "version": "0.0.1",
+      "bin": {
+        "otter": "./dist/cli.js",
+      },
+      "dependencies": {
+        "@mariozechner/pi-agent-core": "^0.64.0",
+        "@otter-agent/core": "workspace:*",
+      },
+    },
   },
   "packages": {
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
@@ -164,6 +175,8 @@
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
     "@mongodb-js/zstd": ["@mongodb-js/zstd@7.0.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" } }, "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA=="],
+
+    "@otter-agent/cli": ["@otter-agent/cli@workspace:packages/otter-agent-cli"],
 
     "@otter-agent/core": ["@otter-agent/core@workspace:packages/otter-agent"],
 

--- a/packages/otter-agent-cli/package.json
+++ b/packages/otter-agent-cli/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@otter-agent/cli",
+	"version": "0.0.1",
+	"type": "module",
+	"bin": {
+		"otter": "./dist/cli.js"
+	},
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc",
+		"test": "bun test",
+		"dev": "tsc --watch"
+	},
+	"dependencies": {
+		"@otter-agent/core": "workspace:*",
+		"@mariozechner/pi-agent-core": "^0.64.0"
+	}
+}

--- a/packages/otter-agent-cli/src/args.test.ts
+++ b/packages/otter-agent-cli/src/args.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { parseCliArgs } from "./args.js";
+
+describe("parseCliArgs", () => {
+	test("defaults to rpc mode", () => {
+		const args = parseCliArgs([]);
+		expect(args.mode).toBe("rpc");
+	});
+
+	test("parses --provider and --model", () => {
+		const args = parseCliArgs(["--provider", "anthropic", "--model", "claude-sonnet-4-5-20250514"]);
+		expect(args.provider).toBe("anthropic");
+		expect(args.model).toBe("claude-sonnet-4-5-20250514");
+	});
+
+	test("parses --thinking with all valid levels", () => {
+		const levels = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+		for (const level of levels) {
+			const args = parseCliArgs(["--thinking", level]);
+			expect(args.thinking).toBe(level);
+		}
+	});
+
+	test("parses --system-prompt", () => {
+		const args = parseCliArgs(["--system-prompt", "You are a helpful assistant."]);
+		expect(args.systemPrompt).toBe("You are a helpful assistant.");
+	});
+
+	test("parses --cwd", () => {
+		const args = parseCliArgs(["--cwd", "/workspace"]);
+		expect(args.cwd).toBe("/workspace");
+	});
+
+	test("sets help flag", () => {
+		const args = parseCliArgs(["--help"]);
+		expect(args.help).toBe(true);
+	});
+
+	test("sets version flag", () => {
+		const args = parseCliArgs(["--version"]);
+		expect(args.version).toBe(true);
+	});
+
+	test("returns undefined for unprovided optional fields", () => {
+		const args = parseCliArgs([]);
+		expect(args.provider).toBeUndefined();
+		expect(args.model).toBeUndefined();
+		expect(args.thinking).toBeUndefined();
+		expect(args.systemPrompt).toBeUndefined();
+		expect(args.cwd).toBeUndefined();
+	});
+});

--- a/packages/otter-agent-cli/src/args.ts
+++ b/packages/otter-agent-cli/src/args.ts
@@ -1,0 +1,77 @@
+import { parseArgs } from "node:util";
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+
+const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
+
+export interface ParsedArgs {
+	mode: "rpc";
+	provider: string | undefined;
+	model: string | undefined;
+	thinking: ThinkingLevel | undefined;
+	systemPrompt: string | undefined;
+	cwd: string | undefined;
+	help: boolean;
+	version: boolean;
+}
+
+const HELP = `
+Usage: otter [options]
+
+Options:
+  --mode <mode>           Operation mode. Currently only "rpc" is supported.
+  --provider <name>       LLM provider (e.g. anthropic, openai, google).
+  --model <id>            Model ID (e.g. claude-sonnet-4-5-20250514).
+  --thinking <level>      Thinking level: off, minimal, low, medium, high, xhigh.
+  --system-prompt <text>  Base system prompt.
+  --cwd <path>            Working directory for the agent environment.
+  --help                  Show this help message.
+  --version               Print the version and exit.
+`.trim();
+
+export function parseCliArgs(argv: string[]): ParsedArgs {
+	const { values } = parseArgs({
+		args: argv,
+		options: {
+			mode: { type: "string" },
+			provider: { type: "string" },
+			model: { type: "string" },
+			thinking: { type: "string" },
+			"system-prompt": { type: "string" },
+			cwd: { type: "string" },
+			help: { type: "boolean", default: false },
+			version: { type: "boolean", default: false },
+		},
+		strict: false,
+	});
+
+	if (values.mode !== undefined && values.mode !== "rpc") {
+		console.error(`Error: unsupported mode "${values.mode}". Only "rpc" is supported.`);
+		process.exit(1);
+	}
+
+	let thinking: ThinkingLevel | undefined;
+	if (values.thinking !== undefined) {
+		if (!THINKING_LEVELS.includes(values.thinking as ThinkingLevel)) {
+			console.error(
+				`Error: invalid thinking level "${values.thinking}". Valid values: ${THINKING_LEVELS.join(", ")}`,
+			);
+			process.exit(1);
+		}
+		thinking = values.thinking as ThinkingLevel;
+	}
+
+	return {
+		mode: "rpc",
+		provider: values.provider as string | undefined,
+		model: values.model as string | undefined,
+		thinking,
+		systemPrompt: values["system-prompt"] as string | undefined,
+		cwd: values.cwd as string | undefined,
+		help: (values.help as boolean | undefined) ?? false,
+		version: (values.version as boolean | undefined) ?? false,
+	};
+}
+
+export function printHelp(): void {
+	console.log(HELP);
+}

--- a/packages/otter-agent-cli/src/cli.ts
+++ b/packages/otter-agent-cli/src/cli.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { main } from "./main.js";
+
+main(process.argv.slice(2)).catch((err) => {
+	process.stderr.write(`Fatal error: ${err instanceof Error ? err.message : String(err)}\n`);
+	process.exit(1);
+});

--- a/packages/otter-agent-cli/src/index.ts
+++ b/packages/otter-agent-cli/src/index.ts
@@ -1,0 +1,5 @@
+// Public API for programmatic use of the CLI package.
+export { main } from "./main.js";
+export { runRpcMode } from "./rpc/rpc-mode.js";
+export { StdioTransport } from "./rpc/stdio-transport.js";
+export { attachJsonlLineReader, serializeJsonLine } from "./rpc/jsonl.js";

--- a/packages/otter-agent-cli/src/main.ts
+++ b/packages/otter-agent-cli/src/main.ts
@@ -1,0 +1,107 @@
+import {
+	AgentEnvironment,
+	type AuthStorage,
+	ModelRegistry,
+	createAgentSession,
+	createInMemoryAuthStorage,
+	createInMemorySessionManager,
+} from "@otter-agent/core";
+import { parseCliArgs, printHelp } from "./args.js";
+import { runRpcMode } from "./rpc/rpc-mode.js";
+
+const VERSION = "0.0.1";
+
+/**
+ * Standard environment variable names for LLM provider API keys.
+ * Keyed by provider identifier as used in pi-ai/ModelRegistry.
+ */
+const PROVIDER_ENV_VARS: Record<string, string> = {
+	anthropic: "ANTHROPIC_API_KEY",
+	openai: "OPENAI_API_KEY",
+	google: "GEMINI_API_KEY",
+	deepseek: "DEEPSEEK_API_KEY",
+	mistral: "MISTRAL_API_KEY",
+	xai: "XAI_API_KEY",
+	openrouter: "OPENROUTER_API_KEY",
+};
+
+/**
+ * Build an InMemoryAuthStorage seeded from standard environment variables.
+ */
+function buildAuthStorageFromEnv() {
+	const keys: Record<string, string> = {};
+	for (const [provider, envVar] of Object.entries(PROVIDER_ENV_VARS)) {
+		const value = process.env[envVar];
+		if (value) {
+			keys[provider] = value;
+		}
+	}
+	return createInMemoryAuthStorage(keys);
+}
+
+/**
+ * Resolve a Model<Api> from CLI --provider and --model flags.
+ *
+ * Exits the process with an error message if the combination is invalid.
+ * Returns undefined when neither flag is provided (session will be modelless).
+ */
+function resolveModelFromArgs(
+	provider: string | undefined,
+	modelId: string | undefined,
+	authStorage: AuthStorage,
+) {
+	if (provider && modelId) {
+		const registry = new ModelRegistry(authStorage);
+		const model = registry.find(provider, modelId);
+		if (!model) {
+			console.error(`Error: model "${provider}/${modelId}" not found.`);
+			console.error("Check --provider and --model values, or omit them to use the default.");
+			process.exit(1);
+		}
+		return model;
+	}
+	if (provider || modelId) {
+		console.error("Error: --provider and --model must be specified together.");
+		process.exit(1);
+	}
+	return undefined;
+}
+
+export async function main(argv: string[]): Promise<void> {
+	const args = parseCliArgs(argv);
+
+	if (args.help) {
+		printHelp();
+		process.exit(0);
+	}
+
+	if (args.version) {
+		console.log(VERSION);
+		process.exit(0);
+	}
+
+	const authStorage = buildAuthStorageFromEnv();
+
+	// Resolve the model from CLI flags before creating the session.
+	// We need a temporary ModelRegistry here because createAgentSession requires a
+	// resolved Model<Api> object, not raw provider/modelId strings. createAgentSession
+	// constructs its own registry internally for session-context resolution — this one
+	// is only used for early CLI validation.
+	const model = resolveModelFromArgs(args.provider, args.model, authStorage);
+
+	const sessionManager = createInMemorySessionManager();
+	const environment = AgentEnvironment.justBash({
+		cwd: args.cwd ?? process.cwd(),
+	});
+
+	const { session } = await createAgentSession({
+		sessionManager,
+		authStorage,
+		environment,
+		systemPrompt: args.systemPrompt ?? "You are a helpful AI assistant.",
+		model,
+		thinkingLevel: args.thinking,
+	});
+
+	await runRpcMode(session);
+}

--- a/packages/otter-agent-cli/src/rpc/jsonl.test.ts
+++ b/packages/otter-agent-cli/src/rpc/jsonl.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
+
+describe("serializeJsonLine", () => {
+	test("serializes a simple object with a trailing newline", () => {
+		const result = serializeJsonLine({ type: "ping" });
+		expect(result).toBe('{"type":"ping"}\n');
+	});
+
+	test("serializes strings, numbers, and arrays", () => {
+		expect(serializeJsonLine("hello")).toBe('"hello"\n');
+		expect(serializeJsonLine(42)).toBe("42\n");
+		expect(serializeJsonLine([1, 2])).toBe("[1,2]\n");
+	});
+
+	test("preserves Unicode separators inside strings", () => {
+		// U+2028 (line separator) and U+2029 (paragraph separator) are valid JSON string chars
+		// and must NOT be used as line boundaries.
+		const value = { text: "line\u2028separator" };
+		const line = serializeJsonLine(value);
+		expect(line.endsWith("\n")).toBe(true);
+		expect(JSON.parse(line.trimEnd())).toEqual(value);
+	});
+});
+
+describe("attachJsonlLineReader", () => {
+	function makeStream(chunks: string[]): NodeJS.ReadableStream {
+		const emitter = new EventEmitter() as NodeJS.ReadableStream;
+		// Emit asynchronously so listeners are attached first.
+		setTimeout(() => {
+			for (const chunk of chunks) {
+				(emitter as EventEmitter).emit("data", Buffer.from(chunk));
+			}
+			(emitter as EventEmitter).emit("end");
+		}, 0);
+		return emitter;
+	}
+
+	test("emits one line per JSONL record", async () => {
+		const lines: string[] = [];
+		const stream = makeStream(['{"a":1}\n{"b":2}\n']);
+		await new Promise<void>((resolve) => {
+			attachJsonlLineReader(stream, (line) => {
+				lines.push(line);
+				if (lines.length === 2) resolve();
+			});
+		});
+		expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+	});
+
+	test("handles records split across multiple chunks", async () => {
+		const lines: string[] = [];
+		const stream = makeStream(['{"ty', 'pe":"ping"}\n']);
+		await new Promise<void>((resolve) => {
+			attachJsonlLineReader(stream, (line) => {
+				lines.push(line);
+				resolve();
+			});
+		});
+		expect(lines).toEqual(['{"type":"ping"}']);
+	});
+
+	test("strips trailing \\r from CRLF input", async () => {
+		const lines: string[] = [];
+		const stream = makeStream(['{"type":"ping"}\r\n']);
+		await new Promise<void>((resolve) => {
+			attachJsonlLineReader(stream, (line) => {
+				lines.push(line);
+				resolve();
+			});
+		});
+		expect(lines).toEqual(['{"type":"ping"}']);
+	});
+
+	test("does not split on Unicode line separators (U+2028)", async () => {
+		const lines: string[] = [];
+		const payload = JSON.stringify({ text: "line\u2028sep" });
+		const stream = makeStream([`${payload}\n`]);
+		await new Promise<void>((resolve) => {
+			attachJsonlLineReader(stream, (line) => {
+				lines.push(line);
+				resolve();
+			});
+		});
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0])).toEqual({ text: "line\u2028sep" });
+	});
+
+	test("returns a cleanup function that stops further processing", async () => {
+		const lines: string[] = [];
+		const emitter = new EventEmitter() as NodeJS.ReadableStream;
+		const detach = attachJsonlLineReader(emitter as NodeJS.ReadableStream, (line) => {
+			lines.push(line);
+		});
+		detach();
+		(emitter as EventEmitter).emit("data", Buffer.from('{"type":"ignored"}\n'));
+		// Give any async callbacks a chance to fire.
+		await new Promise((r) => setTimeout(r, 10));
+		expect(lines).toHaveLength(0);
+	});
+});

--- a/packages/otter-agent-cli/src/rpc/jsonl.ts
+++ b/packages/otter-agent-cli/src/rpc/jsonl.ts
@@ -1,0 +1,60 @@
+import { StringDecoder } from "node:string_decoder";
+
+/**
+ * Serialize a single strict JSONL record.
+ *
+ * Framing is LF-only. Payload strings may contain other Unicode separators
+ * such as U+2028 and U+2029. Clients must split records on `\n` only.
+ */
+export function serializeJsonLine(value: unknown): string {
+	return `${JSON.stringify(value)}\n`;
+}
+
+/**
+ * Attach an LF-only JSONL reader to a readable stream.
+ *
+ * This intentionally does not use Node's `readline`. Readline splits on
+ * additional Unicode separators (U+2028, U+2029) that are valid inside JSON
+ * strings and therefore does not implement strict JSONL framing.
+ *
+ * Returns a cleanup function that removes the listeners.
+ */
+export function attachJsonlLineReader(
+	stream: NodeJS.ReadableStream,
+	onLine: (line: string) => void,
+): () => void {
+	const decoder = new StringDecoder("utf8");
+	let buffer = "";
+
+	const emitLine = (line: string): void => {
+		onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+	};
+
+	const onData = (chunk: Buffer | string): void => {
+		buffer += typeof chunk === "string" ? chunk : decoder.write(chunk);
+		while (true) {
+			const newlineIndex = buffer.indexOf("\n");
+			if (newlineIndex === -1) {
+				return;
+			}
+			emitLine(buffer.slice(0, newlineIndex));
+			buffer = buffer.slice(newlineIndex + 1);
+		}
+	};
+
+	const onEnd = (): void => {
+		buffer += decoder.end();
+		if (buffer.length > 0) {
+			emitLine(buffer);
+			buffer = "";
+		}
+	};
+
+	stream.on("data", onData);
+	stream.on("end", onEnd);
+
+	return () => {
+		stream.off("data", onData);
+		stream.off("end", onEnd);
+	};
+}

--- a/packages/otter-agent-cli/src/rpc/rpc-mode.ts
+++ b/packages/otter-agent-cli/src/rpc/rpc-mode.ts
@@ -1,0 +1,23 @@
+import { type AgentSession, RpcHandler } from "@otter-agent/core";
+import { StdioTransport } from "./stdio-transport.js";
+
+/**
+ * Run the agent in RPC mode.
+ *
+ * Creates a StdioTransport, wires it to an RpcHandler, sets up the
+ * UIProvider on the session, and blocks forever — the process exits
+ * only when killed externally.
+ */
+export async function runRpcMode(session: AgentSession): Promise<void> {
+	const transport = new StdioTransport();
+	const handler = new RpcHandler({ session, transport });
+
+	// Wire the UIProvider created by RpcHandler into the session so
+	// that extensions loaded after session construction can use it.
+	session.setUIProvider(handler.uiProvider);
+
+	handler.start();
+
+	// Block forever — RPC mode runs until the process is killed.
+	return new Promise(() => {});
+}

--- a/packages/otter-agent-cli/src/rpc/stdio-transport.ts
+++ b/packages/otter-agent-cli/src/rpc/stdio-transport.ts
@@ -1,0 +1,57 @@
+import type { RpcInboundMessage, RpcOutboundMessage, RpcTransport } from "@otter-agent/core";
+import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
+
+/**
+ * Concrete RpcTransport implementation over process.stdin / process.stdout.
+ *
+ * Inbound messages are read as strict JSONL from stdin.
+ * Outbound messages are serialised as JSONL and written to stdout.
+ *
+ * Stdout is taken over at construction time: console.log and console.warn
+ * are redirected to stderr so that stray log output cannot corrupt the
+ * protocol stream.
+ */
+export class StdioTransport implements RpcTransport {
+	private _detachReader: (() => void) | undefined;
+	private _originalConsoleLog: typeof console.log;
+	private _originalConsoleWarn: typeof console.warn;
+	private _originalConsoleInfo: typeof console.info;
+
+	constructor() {
+		// Redirect console methods to stderr to protect the JSONL stream.
+		this._originalConsoleLog = console.log;
+		this._originalConsoleWarn = console.warn;
+		this._originalConsoleInfo = console.info;
+		console.log = (...args) => process.stderr.write(`[log] ${args.join(" ")}\n`);
+		console.warn = (...args) => process.stderr.write(`[warn] ${args.join(" ")}\n`);
+		console.info = (...args) => process.stderr.write(`[info] ${args.join(" ")}\n`);
+	}
+
+	onMessage(handler: (message: RpcInboundMessage) => void): void {
+		this._detachReader = attachJsonlLineReader(process.stdin, (line) => {
+			if (!line.trim()) return;
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(line);
+			} catch {
+				// Silently discard malformed lines — callers can't recover from parse errors.
+				return;
+			}
+			handler(parsed as RpcInboundMessage);
+		});
+	}
+
+	send(message: RpcOutboundMessage): void {
+		process.stdout.write(serializeJsonLine(message));
+	}
+
+	close(): void {
+		this._detachReader?.();
+		this._detachReader = undefined;
+
+		// Restore console methods.
+		console.log = this._originalConsoleLog;
+		console.warn = this._originalConsoleWarn;
+		console.info = this._originalConsoleInfo;
+	}
+}

--- a/packages/otter-agent-cli/tsconfig.json
+++ b/packages/otter-agent-cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -171,7 +171,7 @@ export class AgentSession {
 	readonly sessionManager: SessionManager;
 
 	/** Optional UI provider for extensions. */
-	readonly uiProvider: UIProvider | undefined;
+	uiProvider: UIProvider | undefined;
 
 	/** Model registry for provider management. */
 	readonly modelRegistry: ModelRegistry;
@@ -289,6 +289,17 @@ export class AgentSession {
 	/** Get the extension runner for direct access (commands, error listeners, etc). */
 	get extensionRunner(): ExtensionRunner {
 		return this._extensionRunner;
+	}
+
+	/**
+	 * Set the UI provider for extension interaction after construction.
+	 *
+	 * Useful when the UIProvider depends on the session (e.g. RpcUIProvider
+	 * created alongside an RpcHandler after the session is constructed).
+	 */
+	setUIProvider(provider: UIProvider): void {
+		this.uiProvider = provider;
+		this._extensionRunner.setUIProvider(provider);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds a new `@otter-agent/cli` package (`packages/otter-agent-cli/`) that launches an OtterAgent in RPC mode
- External applications can spawn `otter --mode rpc` as a subprocess and communicate over stdin/stdout via the existing JSONL protocol
- Adds `AgentSession.setUIProvider()` to `@otter-agent/core` to support post-construction UIProvider wiring

## New package: `@otter-agent/cli`

| File | Purpose |
|------|---------|
| `src/cli.ts` | Entry point shim — registered as `bin.otter` |
| `src/args.ts` | CLI arg parsing via `node:util` (no external deps) |
| `src/main.ts` | Bootstrap: auth from env vars, model resolution, session wiring |
| `src/rpc/jsonl.ts` | Strict LF-only JSONL framing (ported from pi-coding-agent) |
| `src/rpc/stdio-transport.ts` | `RpcTransport` over stdin/stdout; redirects console to stderr |
| `src/rpc/rpc-mode.ts` | Wires transport + handler, blocks forever |

## Test plan

- [x] Build passes (`bun run build`)
- [x] Lint passes (`bun run lint`)
- [x] 332 core tests pass, 16 new CLI tests pass (348 total)
- [x] Smoke tested: `echo '{"type":"get_state","id":"1"}' | node dist/cli.js --mode rpc` returns valid JSONL
- [x] Independent code review run (twice) — issues found and addressed

## Related issues

Closes #47
Tracked for follow-up: #49 (UIProvider wiring pattern), #52 (graceful shutdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)