### PR TITLE
Merge improve-plan-mode changes into main

### DIFF
--- a/.pi/extensions/mode/index.ts
+++ b/.pi/extensions/mode/index.ts
@@ -21,6 +21,8 @@ import { developConfig } from "./develop.js";
 import { planConfig } from "./plan.js";
 import type { ModeConfig } from "./types.js";
 
+const PLAN_DEACTIVATED_MESSAGE = "Plan mode has been deactivated. You may now make file writes, edits, and other changes as needed.";
+
 const MODES: Record<string, ModeConfig> = {
 	plan: planConfig,
 	develop: developConfig,
@@ -55,6 +57,8 @@ export default function modeExtension(pi: ExtensionAPI): void {
 	}
 
 	function setMode(mode: string | null, state: Record<string, unknown> | undefined, ctx: ExtensionContext, force = false): void {
+		const previousMode = activeMode;
+
 		// Toggle off if same mode already active (unless forced)
 		if (!force && mode !== null && activeMode === mode) {
 			mode = null;
@@ -74,6 +78,15 @@ export default function modeExtension(pi: ExtensionAPI): void {
 			ctx.ui.notify(`Mode: ${label}`, "info");
 		} else {
 			ctx.ui.notify("Mode cleared", "info");
+		}
+
+		// Send deactivation message when leaving plan mode
+		if (previousMode === "plan" && activeMode !== "plan") {
+			pi.sendMessage({
+				customType: "plan-deactivated",
+				content: PLAN_DEACTIVATED_MESSAGE,
+				display: true,
+			});
 		}
 	}
 
@@ -175,6 +188,7 @@ export default function modeExtension(pi: ExtensionAPI): void {
 	pi.on("context", async (event) => {
 		const inactiveCustomTypes: string[] = [];
 		if (activeMode !== "develop") inactiveCustomTypes.push("develop-context");
+		if (activeMode !== "plan") inactiveCustomTypes.push("plan-context");
 
 		if (inactiveCustomTypes.length === 0) return;
 

--- a/.pi/extensions/mode/plan.ts
+++ b/.pi/extensions/mode/plan.ts
@@ -1,7 +1,30 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { ModeConfig } from "./types.js";
+
+const PLAN_WORKFLOW_INSTRUCTIONS = `You are in plan mode. Follow this workflow:
+
+1. Explore the codebase to gather the context required to contribute to the planning session effectively.
+2. Raise any open questions you have for the user. Continue across multiple turns until all your questions are answered.
+3. Once you have no more open questions, output a full implementation plan with specific steps, files to change, and the approach for each change. Ask the user for approval or additional feedback.
+
+Do NOT make any file writes, edits, or execute commands that modify the filesystem. Focus entirely on understanding requirements and producing a plan.`;
+
+async function planBeforeAgentStart(
+	_modeState: Record<string, unknown> | undefined,
+	_ctx: ExtensionContext,
+	_pi: ExtensionAPI,
+): Promise<{ message: { customType: string; content: string; display: boolean } } | void> {
+	return {
+		message: {
+			customType: "plan-context",
+			content: PLAN_WORKFLOW_INSTRUCTIONS,
+			display: true,
+		},
+	};
+}
 
 export const planConfig: ModeConfig = {
 	label: "📋 plan",
-	suffix:
-		"Remember we are in a planning session so you should not be making any writes or edits. Address my comments and raise any further open questions you have. If you have no open questions respond with your current implementation plan.",
+	suffix: "Remember you are currently in plan mode",
+	beforeAgentStart: planBeforeAgentStart,
 };


### PR DESCRIPTION
Merge the plan mode improvements from PR #51 (merged to `pi-coding-agent-improvements`) into `main`.

**Changes:**
- Add `beforeAgentStart` hook to plan mode that injects a displayed context message explaining the workflow (explore → questions → plan) and rules (no writes/edits)
- Simplify the user message suffix to a short reminder: "Remember you are currently in plan mode"
- Send a displayed deactivation message when leaving plan mode
- Filter out stale `plan-context` messages when plan mode is inactive

Closes #50