### PR TITLE
refactor: unify mode activation/deactivation pattern for plan and develop modes

### DIFF
--- a/.pi/extensions/mode/develop.ts
+++ b/.pi/extensions/mode/develop.ts
@@ -1,7 +1,6 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { ModeConfig } from "./types.js";
 
-const DEVELOP_WORKFLOW_INSTRUCTIONS = `You are in develop mode. Follow this workflow:
+export const DEVELOP_WORKFLOW_INSTRUCTIONS = `You are in develop mode. Follow this workflow:
 
 1. If you are on the main branch, create a new branch. Choose an appropriate name based on the work.
 2. If an issue number is provided, review it with \`gh issue view <number> --comments\`. If it's missing decisions or is outdated, update it.
@@ -9,66 +8,7 @@ const DEVELOP_WORKFLOW_INSTRUCTIONS = `You are in develop mode. Follow this work
 4. Complete the development work.
 5. Once the work is complete, commit with a descriptive message and post a comment on the issue summarizing what was done.`;
 
-/**
- * Parse a git remote URL to extract the owner/repo slug.
- * Handles both HTTPS and SSH formats.
- */
-function parseRepoSlug(remoteUrl: string): string | null {
-	// HTTPS: https://github.com/owner/repo.git
-	const httpsMatch = remoteUrl.match(/github\.com[/:]([^/]+)\/([^/\s]+?)(?:\.git)?$/);
-	if (httpsMatch) return `${httpsMatch[1]}/${httpsMatch[2]}`;
-
-	// SSH: git@github.com:owner/repo.git
-	const sshMatch = remoteUrl.match(/git@[^:]+:([^/]+)\/([^/\s]+?)(?:\.git)?$/);
-	if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`;
-
-	return null;
-}
-
-async function developBeforeAgentStart(
-	modeState: Record<string, unknown> | undefined,
-	_ctx: ExtensionContext,
-	pi: ExtensionAPI,
-): Promise<{ message: { customType: string; content: string; display: boolean } } | void> {
-	// Fetch repo slug every turn (not cached) so branch changes are reflected
-	let repoLine = "";
-	try {
-		const { stdout, code } = await pi.exec("git", ["remote", "get-url", "origin"]);
-		if (code === 0 && stdout.trim()) {
-			const slug = parseRepoSlug(stdout.trim());
-			if (slug) {
-				repoLine = `\nRepository: ${slug}`;
-			}
-		}
-	} catch {
-		// git not available or no remote — omit repo line
-	}
-
-	// Build issue/description context based on modeState
-	let issueContext = "";
-	const issueNumber = modeState?.issueNumber;
-	const description = modeState?.description;
-
-	if (typeof issueNumber === "number") {
-		issueContext = `\nIssue: #${issueNumber}`;
-	} else if (typeof description === "string") {
-		issueContext = `\nNo issue exists yet — create one first.\nDescription: ${description}`;
-	} else {
-		issueContext = "\nNo issue or description provided — ask the user what they want to work on.";
-	}
-
-	const content = `${DEVELOP_WORKFLOW_INSTRUCTIONS}${repoLine}${issueContext}`;
-
-	return {
-		message: {
-			customType: "develop-context",
-			content,
-			display: false,
-		},
-	};
-}
-
 export const developConfig: ModeConfig = {
 	label: "🔨 develop",
-	beforeAgentStart: developBeforeAgentStart,
+	suffix: "Remember you are currently in develop mode",
 };

--- a/.pi/extensions/mode/index.ts
+++ b/.pi/extensions/mode/index.ts
@@ -3,7 +3,7 @@
  *
  * Lightweight, mutually exclusive mode system for project-specific agent modes.
  * Only one mode can be active at a time. Modes can provide a prompt suffix,
- * a dynamic beforeAgentStart hook, or both.
+ * an activation message, or both.
  *
  * Commands:
  *   /mode               — clear active mode
@@ -17,16 +17,71 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { developConfig } from "./develop.js";
-import { planConfig } from "./plan.js";
+import { DEVELOP_WORKFLOW_INSTRUCTIONS, developConfig } from "./develop.js";
+import { PLAN_WORKFLOW_INSTRUCTIONS, planConfig } from "./plan.js";
 import type { ModeConfig } from "./types.js";
 
-const PLAN_DEACTIVATED_MESSAGE = "Plan mode has been deactivated. You may now make file writes, edits, and other changes as needed.";
+const PLAN_DEACTIVATED_MESSAGE =
+	"Plan mode has been deactivated. You may now make file writes, edits, and other changes as needed.";
+
+const DEVELOP_DEACTIVATED_MESSAGE = "Develop mode has been deactivated.";
 
 const MODES: Record<string, ModeConfig> = {
 	plan: planConfig,
 	develop: developConfig,
 };
+
+/**
+ * Parse a git remote URL to extract the owner/repo slug.
+ * Handles both HTTPS and SSH formats.
+ */
+function parseRepoSlug(remoteUrl: string): string | null {
+	// HTTPS: https://github.com/owner/repo.git
+	const httpsMatch = remoteUrl.match(/github\.com[/:]([^/]+)\/([^/\s]+?)(?:\.git)?$/);
+	if (httpsMatch) return `${httpsMatch[1]}/${httpsMatch[2]}`;
+
+	// SSH: git@github.com:owner/repo.git
+	const sshMatch = remoteUrl.match(/git@[^:]+:([^/]+)\/([^/\s]+?)(?:\.git)?$/);
+	if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`;
+
+	return null;
+}
+
+/**
+ * Build the full activation message content for develop mode.
+ * Includes the static workflow instructions plus dynamic repo slug and issue context.
+ */
+async function buildDevelopActivationContent(
+	modeState: Record<string, unknown> | undefined,
+	pi: ExtensionAPI,
+): Promise<string> {
+	let repoLine = "";
+	try {
+		const { stdout, code } = await pi.exec("git", ["remote", "get-url", "origin"]);
+		if (code === 0 && stdout.trim()) {
+			const slug = parseRepoSlug(stdout.trim());
+			if (slug) {
+				repoLine = `\nRepository: ${slug}`;
+			}
+		}
+	} catch {
+		// git not available or no remote — omit repo line
+	}
+
+	let issueContext = "";
+	const issueNumber = modeState?.issueNumber;
+	const description = modeState?.description;
+
+	if (typeof issueNumber === "number") {
+		issueContext = `\nIssue: #${issueNumber}`;
+	} else if (typeof description === "string") {
+		issueContext = `\nNo issue exists yet — create one first.\nDescription: ${description}`;
+	} else {
+		issueContext = "\nNo issue or description provided — ask the user what they want to work on.";
+	}
+
+	return `${DEVELOP_WORKFLOW_INSTRUCTIONS}${repoLine}${issueContext}`;
+}
 
 export default function modeExtension(pi: ExtensionAPI): void {
 	let activeMode: string | null = null;
@@ -56,7 +111,12 @@ export default function modeExtension(pi: ExtensionAPI): void {
 		}
 	}
 
-	function setMode(mode: string | null, state: Record<string, unknown> | undefined, ctx: ExtensionContext, force = false): void {
+	async function setMode(
+		mode: string | null,
+		state: Record<string, unknown> | undefined,
+		ctx: ExtensionContext,
+		force = false,
+	): Promise<void> {
 		const previousMode = activeMode;
 
 		// Toggle off if same mode already active (unless forced)
@@ -76,15 +136,38 @@ export default function modeExtension(pi: ExtensionAPI): void {
 					? buildDevelopLabel(modeState)
 					: MODES[activeMode].label;
 			ctx.ui.notify(`Mode: ${label}`, "info");
+
+			// Send one-time activation message
+			if (activeMode === "plan") {
+				pi.sendMessage({
+					customType: "plan-context",
+					content: PLAN_WORKFLOW_INSTRUCTIONS,
+					display: true,
+				});
+			} else if (activeMode === "develop") {
+				const content = await buildDevelopActivationContent(modeState, pi);
+				pi.sendMessage({
+					customType: "develop-context",
+					content,
+					display: true,
+				});
+			}
 		} else {
 			ctx.ui.notify("Mode cleared", "info");
 		}
 
-		// Send deactivation message when leaving plan mode
+		// Send deactivation messages
 		if (previousMode === "plan" && activeMode !== "plan") {
 			pi.sendMessage({
 				customType: "plan-deactivated",
 				content: PLAN_DEACTIVATED_MESSAGE,
+				display: true,
+			});
+		}
+		if (previousMode === "develop" && activeMode !== "develop") {
+			pi.sendMessage({
+				customType: "develop-deactivated",
+				content: DEVELOP_DEACTIVATED_MESSAGE,
 				display: true,
 			});
 		}
@@ -104,7 +187,7 @@ export default function modeExtension(pi: ExtensionAPI): void {
 			const name = args.trim();
 
 			if (!name) {
-				setMode(null, undefined, ctx);
+				await setMode(null, undefined, ctx);
 				return;
 			}
 
@@ -113,7 +196,7 @@ export default function modeExtension(pi: ExtensionAPI): void {
 				return;
 			}
 
-			setMode(name, undefined, ctx);
+			await setMode(name, undefined, ctx);
 		},
 	});
 
@@ -121,9 +204,9 @@ export default function modeExtension(pi: ExtensionAPI): void {
 		description: "Toggle plan mode",
 		handler: async (_args, ctx) => {
 			if (activeMode === "plan") {
-				setMode(null, undefined, ctx);
+				await setMode(null, undefined, ctx);
 			} else {
-				setMode("plan", undefined, ctx);
+				await setMode("plan", undefined, ctx);
 			}
 		},
 	});
@@ -135,7 +218,7 @@ export default function modeExtension(pi: ExtensionAPI): void {
 
 			// Toggle off if develop is already active
 			if (activeMode === "develop" && !trimmed) {
-				setMode(null, undefined, ctx);
+				await setMode(null, undefined, ctx);
 				return;
 			}
 
@@ -145,22 +228,22 @@ export default function modeExtension(pi: ExtensionAPI): void {
 					ctx.ui.notify('Usage: /develop new <description>', "error");
 					return;
 				}
-				setMode("develop", { description }, ctx, true);
+				await setMode("develop", { description }, ctx, true);
 			} else if (/^\d+$/.test(trimmed)) {
-				setMode("develop", { issueNumber: Number.parseInt(trimmed, 10) }, ctx, true);
+				await setMode("develop", { issueNumber: Number.parseInt(trimmed, 10) }, ctx, true);
 			} else if (trimmed) {
 				ctx.ui.notify('Usage: /develop [ <issue-number> | new <description> ]', "error");
 				return;
 			} else {
 				// /develop with no args while not active — activate with no state
-				setMode("develop", undefined, ctx);
+				await setMode("develop", undefined, ctx);
 			}
 		},
 	});
 
 	// --- Events ---
 
-	// Append suffix to user messages for modes that have one (plan mode)
+	// Append suffix to user messages for modes that have one
 	pi.on("input", async (event) => {
 		if (!activeMode || !(activeMode in MODES)) return;
 		if (event.source === "extension") return;
@@ -171,31 +254,6 @@ export default function modeExtension(pi: ExtensionAPI): void {
 		return {
 			action: "transform",
 			text: `${event.text}\n\n${config.suffix}`,
-		};
-	});
-
-	// Inject dynamic context for modes that have a beforeAgentStart hook (develop mode)
-	pi.on("before_agent_start", async (_event, ctx) => {
-		if (!activeMode || !(activeMode in MODES)) return;
-
-		const config = MODES[activeMode];
-		if (!config.beforeAgentStart) return;
-
-		return config.beforeAgentStart(modeState, ctx, pi);
-	});
-
-	// Filter out stale context messages from inactive modes
-	pi.on("context", async (event) => {
-		const inactiveCustomTypes: string[] = [];
-		if (activeMode !== "develop") inactiveCustomTypes.push("develop-context");
-		if (activeMode !== "plan") inactiveCustomTypes.push("plan-context");
-
-		if (inactiveCustomTypes.length === 0) return;
-
-		return {
-			messages: event.messages.filter((m) => {
-				return !inactiveCustomTypes.includes((m as { customType?: string }).customType ?? "");
-			}),
 		};
 	});
 

--- a/.pi/extensions/mode/plan.ts
+++ b/.pi/extensions/mode/plan.ts
@@ -1,7 +1,6 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { ModeConfig } from "./types.js";
 
-const PLAN_WORKFLOW_INSTRUCTIONS = `You are in plan mode. Follow this workflow:
+export const PLAN_WORKFLOW_INSTRUCTIONS = `You are in plan mode. Follow this workflow:
 
 1. Explore the codebase to gather the context required to contribute to the planning session effectively.
 2. Raise any open questions you have for the user. Continue across multiple turns until all your questions are answered.
@@ -9,22 +8,7 @@ const PLAN_WORKFLOW_INSTRUCTIONS = `You are in plan mode. Follow this workflow:
 
 Do NOT make any file writes, edits, or execute commands that modify the filesystem. Focus entirely on understanding requirements and producing a plan.`;
 
-async function planBeforeAgentStart(
-	_modeState: Record<string, unknown> | undefined,
-	_ctx: ExtensionContext,
-	_pi: ExtensionAPI,
-): Promise<{ message: { customType: string; content: string; display: boolean } } | void> {
-	return {
-		message: {
-			customType: "plan-context",
-			content: PLAN_WORKFLOW_INSTRUCTIONS,
-			display: true,
-		},
-	};
-}
-
 export const planConfig: ModeConfig = {
 	label: "📋 plan",
 	suffix: "Remember you are currently in plan mode",
-	beforeAgentStart: planBeforeAgentStart,
 };

--- a/.pi/extensions/mode/types.ts
+++ b/.pi/extensions/mode/types.ts
@@ -1,11 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-
 export type ModeConfig = {
 	label: string;
 	suffix?: string;
-	beforeAgentStart?: (
-		modeState: Record<string, unknown> | undefined,
-		ctx: ExtensionContext,
-		pi: ExtensionAPI,
-	) => Promise<{ message: { customType: string; content: string; display: boolean } } | void>;
 };


### PR DESCRIPTION
Unify plan and develop modes to follow the same activation/deactivation pattern.

**Changes:**
- Send mode context messages once on activation instead of every turn via `beforeAgentStart`
- Add develop mode deactivation message
- Add suffix to develop mode (`"Remember you are currently in develop mode"`)
- All mode messages use `display: true`
- Remove `beforeAgentStart` hook from `ModeConfig` and both mode implementations
- Remove `context` event handler that filtered stale mode messages
- Move `parseRepoSlug` and repo/issue context building into `index.ts` for one-time activation message
- `setMode()` is now async to support `pi.exec()` for repo slug resolution

**Files changed:**
- `.pi/extensions/mode/types.ts` — remove `beforeAgentStart` field
- `.pi/extensions/mode/plan.ts` — remove hook, export instructions constant
- `.pi/extensions/mode/develop.ts` — remove hook, export instructions constant, add suffix
- `.pi/extensions/mode/index.ts` — one-time activation/deactivation messages, remove `before_agent_start` and `context` handlers

Code review: https://github.com/BowerJames/OtterAgent/issues/55#issuecomment-4195238242

Closes #55