### PR TITLE
feat(cli): add --api-key flag and require --provider/--model

### DIFF
--- a/packages/otter-agent-cli/src/args.test.ts
+++ b/packages/otter-agent-cli/src/args.test.ts
@@ -2,32 +2,66 @@ import { describe, expect, test } from "bun:test";
 import { parseCliArgs } from "./args.js";
 
 describe("parseCliArgs", () => {
+	const baseArgs = ["--provider", "anthropic", "--model", "claude-sonnet-4-5-20250514"];
+
 	test("defaults to rpc mode", () => {
-		const args = parseCliArgs([]);
+		const args = parseCliArgs(baseArgs);
 		expect(args.mode).toBe("rpc");
 	});
 
 	test("parses --provider and --model", () => {
-		const args = parseCliArgs(["--provider", "anthropic", "--model", "claude-sonnet-4-5-20250514"]);
+		const args = parseCliArgs(baseArgs);
 		expect(args.provider).toBe("anthropic");
 		expect(args.model).toBe("claude-sonnet-4-5-20250514");
+	});
+
+	test("exits when --provider is missing", async () => {
+		const cliPath = new URL("../dist/cli.js", import.meta.url).pathname;
+		const proc = Bun.spawn(["bun", "run", cliPath, "--model", "claude-sonnet-4-5-20250514"], {
+			stderr: "pipe",
+		});
+		await proc.exited;
+		expect(proc.exitCode).toBe(1);
+		const stderr = await new Response(proc.stderr).text();
+		expect(stderr).toContain("--provider is required");
+	});
+
+	test("exits when --model is missing", async () => {
+		const cliPath = new URL("../dist/cli.js", import.meta.url).pathname;
+		const proc = Bun.spawn(["bun", "run", cliPath, "--provider", "anthropic"], {
+			stderr: "pipe",
+		});
+		await proc.exited;
+		expect(proc.exitCode).toBe(1);
+		const stderr = await new Response(proc.stderr).text();
+		expect(stderr).toContain("--model is required");
+	});
+
+	test("parses --api-key", () => {
+		const args = parseCliArgs([...baseArgs, "--api-key", "sk-test-key"]);
+		expect(args.apiKey).toBe("sk-test-key");
+	});
+
+	test("defaults apiKey to undefined when not provided", () => {
+		const args = parseCliArgs(baseArgs);
+		expect(args.apiKey).toBeUndefined();
 	});
 
 	test("parses --thinking with all valid levels", () => {
 		const levels = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
 		for (const level of levels) {
-			const args = parseCliArgs(["--thinking", level]);
+			const args = parseCliArgs([...baseArgs, "--thinking", level]);
 			expect(args.thinking).toBe(level);
 		}
 	});
 
 	test("parses --system-prompt", () => {
-		const args = parseCliArgs(["--system-prompt", "You are a helpful assistant."]);
+		const args = parseCliArgs([...baseArgs, "--system-prompt", "You are a helpful assistant."]);
 		expect(args.systemPrompt).toBe("You are a helpful assistant.");
 	});
 
 	test("parses --cwd", () => {
-		const args = parseCliArgs(["--cwd", "/workspace"]);
+		const args = parseCliArgs([...baseArgs, "--cwd", "/workspace"]);
 		expect(args.cwd).toBe("/workspace");
 	});
 
@@ -42,11 +76,10 @@ describe("parseCliArgs", () => {
 	});
 
 	test("returns undefined for unprovided optional fields", () => {
-		const args = parseCliArgs([]);
-		expect(args.provider).toBeUndefined();
-		expect(args.model).toBeUndefined();
+		const args = parseCliArgs(baseArgs);
 		expect(args.thinking).toBeUndefined();
 		expect(args.systemPrompt).toBeUndefined();
 		expect(args.cwd).toBeUndefined();
+		expect(args.apiKey).toBeUndefined();
 	});
 });

--- a/packages/otter-agent-cli/src/args.ts
+++ b/packages/otter-agent-cli/src/args.ts
@@ -5,8 +5,9 @@ const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "hi
 
 export interface ParsedArgs {
 	mode: "rpc";
-	provider: string | undefined;
-	model: string | undefined;
+	provider: string;
+	model: string;
+	apiKey: string | undefined;
 	thinking: ThinkingLevel | undefined;
 	systemPrompt: string | undefined;
 	cwd: string | undefined;
@@ -19,8 +20,9 @@ Usage: otter [options]
 
 Options:
   --mode <mode>           Operation mode. Currently only "rpc" is supported.
-  --provider <name>       LLM provider (e.g. anthropic, openai, google).
-  --model <id>            Model ID (e.g. claude-sonnet-4-5-20250514).
+  --provider <name>       LLM provider (e.g. anthropic, openai, google). Required.
+  --model <id>            Model ID (e.g. claude-sonnet-4-5-20250514). Required.
+  --api-key <key>         API key for the provider. Overrides the environment variable.
   --thinking <level>      Thinking level: off, minimal, low, medium, high, xhigh.
   --system-prompt <text>  Base system prompt.
   --cwd <path>            Working directory for the agent environment.
@@ -35,6 +37,7 @@ export function parseCliArgs(argv: string[]): ParsedArgs {
 			mode: { type: "string" },
 			provider: { type: "string" },
 			model: { type: "string" },
+			"api-key": { type: "string" },
 			thinking: { type: "string" },
 			"system-prompt": { type: "string" },
 			cwd: { type: "string" },
@@ -60,15 +63,51 @@ export function parseCliArgs(argv: string[]): ParsedArgs {
 		thinking = values.thinking as ThinkingLevel;
 	}
 
+	const help = (values.help as boolean | undefined) ?? false;
+	const version = (values.version as boolean | undefined) ?? false;
+
+	// --help and --version short-circuit without requiring --provider/--model.
+	if (help || version) {
+		return {
+			mode: "rpc",
+			provider: "",
+			model: "",
+			apiKey: undefined,
+			thinking,
+			systemPrompt: values["system-prompt"] as string | undefined,
+			cwd: values.cwd as string | undefined,
+			help,
+			version,
+		};
+	}
+
+	const provider = values.provider as string | undefined;
+	const model = values.model as string | undefined;
+
+	if (!provider) {
+		console.error("Error: --provider is required.");
+		console.error(
+			"Use --provider <name> to specify the LLM provider (e.g. anthropic, openai, google).",
+		);
+		process.exit(1);
+	}
+
+	if (!model) {
+		console.error("Error: --model is required.");
+		console.error("Use --model <id> to specify the model ID (e.g. claude-sonnet-4-5-20250514).");
+		process.exit(1);
+	}
+
 	return {
 		mode: "rpc",
-		provider: values.provider as string | undefined,
-		model: values.model as string | undefined,
+		provider,
+		model,
+		apiKey: values["api-key"] as string | undefined,
 		thinking,
 		systemPrompt: values["system-prompt"] as string | undefined,
 		cwd: values.cwd as string | undefined,
-		help: (values.help as boolean | undefined) ?? false,
-		version: (values.version as boolean | undefined) ?? false,
+		help: false,
+		version: false,
 	};
 }
 

--- a/packages/otter-agent-cli/src/auth.test.ts
+++ b/packages/otter-agent-cli/src/auth.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { buildAuthStorageFromEnv } from "./auth.js";
+
+describe("buildAuthStorageFromEnv", () => {
+	test("reads API keys from environment variables", async () => {
+		const originalKey = process.env.ANTHROPIC_API_KEY;
+		process.env.ANTHROPIC_API_KEY = "env-key-123";
+		try {
+			const storage = buildAuthStorageFromEnv();
+			expect(await storage.getApiKey("anthropic")).toBe("env-key-123");
+		} finally {
+			process.env.ANTHROPIC_API_KEY = originalKey;
+		}
+	});
+
+	test("returns undefined for providers with no env var set", async () => {
+		const originalKey = process.env.OPENAI_API_KEY;
+		process.env.OPENAI_API_KEY = undefined;
+		try {
+			const storage = buildAuthStorageFromEnv();
+			expect(await storage.getApiKey("openai")).toBeUndefined();
+		} finally {
+			if (originalKey !== undefined) process.env.OPENAI_API_KEY = originalKey;
+		}
+	});
+
+	test("apiKeyOverride takes precedence over environment variable", async () => {
+		const originalKey = process.env.ANTHROPIC_API_KEY;
+		process.env.ANTHROPIC_API_KEY = "env-key-123";
+		try {
+			const storage = buildAuthStorageFromEnv({ provider: "anthropic", apiKey: "cli-key-456" });
+			expect(await storage.getApiKey("anthropic")).toBe("cli-key-456");
+		} finally {
+			process.env.ANTHROPIC_API_KEY = originalKey;
+		}
+	});
+
+	test("apiKeyOverride adds a key for a provider with no env var", async () => {
+		const originalKey = process.env.OPENAI_API_KEY;
+		process.env.OPENAI_API_KEY = undefined;
+		try {
+			const storage = buildAuthStorageFromEnv({ provider: "openai", apiKey: "cli-key-789" });
+			expect(await storage.getApiKey("openai")).toBe("cli-key-789");
+		} finally {
+			if (originalKey !== undefined) process.env.OPENAI_API_KEY = originalKey;
+		}
+	});
+
+	test("no override and no env vars returns empty storage", async () => {
+		const envBackups: Record<string, string | undefined> = {};
+		for (const envVar of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"]) {
+			envBackups[envVar] = process.env[envVar];
+			delete process.env[envVar];
+		}
+		try {
+			const storage = buildAuthStorageFromEnv();
+			expect(await storage.getApiKey("anthropic")).toBeUndefined();
+			expect(await storage.getApiKey("openai")).toBeUndefined();
+			expect(await storage.getApiKey("google")).toBeUndefined();
+		} finally {
+			for (const [envVar, value] of Object.entries(envBackups)) {
+				if (value !== undefined) process.env[envVar] = value;
+			}
+		}
+	});
+});

--- a/packages/otter-agent-cli/src/auth.ts
+++ b/packages/otter-agent-cli/src/auth.ts
@@ -1,0 +1,39 @@
+import type { AuthStorage } from "@otter-agent/core";
+import { createInMemoryAuthStorage } from "@otter-agent/core";
+
+/**
+ * Standard environment variable names for LLM provider API keys.
+ * Keyed by provider identifier as used in pi-ai/ModelRegistry.
+ */
+export const PROVIDER_ENV_VARS: Record<string, string> = {
+	anthropic: "ANTHROPIC_API_KEY",
+	openai: "OPENAI_API_KEY",
+	google: "GEMINI_API_KEY",
+	deepseek: "DEEPSEEK_API_KEY",
+	mistral: "MISTRAL_API_KEY",
+	xai: "XAI_API_KEY",
+	openrouter: "OPENROUTER_API_KEY",
+};
+
+/**
+ * Build an InMemoryAuthStorage seeded from standard environment variables.
+ *
+ * If `apiKeyOverride` is provided, it is merged into the keys map after
+ * env vars are read, so it takes precedence for the given provider.
+ */
+export function buildAuthStorageFromEnv(apiKeyOverride?: {
+	provider: string;
+	apiKey: string;
+}): AuthStorage {
+	const keys: Record<string, string> = {};
+	for (const [provider, envVar] of Object.entries(PROVIDER_ENV_VARS)) {
+		const value = process.env[envVar];
+		if (value) {
+			keys[provider] = value;
+		}
+	}
+	if (apiKeyOverride) {
+		keys[apiKeyOverride.provider] = apiKeyOverride.apiKey;
+	}
+	return createInMemoryAuthStorage(keys);
+}

--- a/packages/otter-agent-cli/src/main.ts
+++ b/packages/otter-agent-cli/src/main.ts
@@ -1,68 +1,24 @@
-import {
-	AgentEnvironment,
-	type AuthStorage,
-	ModelRegistry,
-	createInMemoryAuthStorage,
-} from "@otter-agent/core";
+import { AgentEnvironment, type AuthStorage, ModelRegistry } from "@otter-agent/core";
 import { parseCliArgs, printHelp } from "./args.js";
+import { buildAuthStorageFromEnv } from "./auth.js";
 import { runRpcMode } from "./rpc/rpc-mode.js";
 
 const VERSION = "0.0.1";
 
 /**
- * Standard environment variable names for LLM provider API keys.
- * Keyed by provider identifier as used in pi-ai/ModelRegistry.
- */
-const PROVIDER_ENV_VARS: Record<string, string> = {
-	anthropic: "ANTHROPIC_API_KEY",
-	openai: "OPENAI_API_KEY",
-	google: "GEMINI_API_KEY",
-	deepseek: "DEEPSEEK_API_KEY",
-	mistral: "MISTRAL_API_KEY",
-	xai: "XAI_API_KEY",
-	openrouter: "OPENROUTER_API_KEY",
-};
-
-/**
- * Build an InMemoryAuthStorage seeded from standard environment variables.
- */
-function buildAuthStorageFromEnv() {
-	const keys: Record<string, string> = {};
-	for (const [provider, envVar] of Object.entries(PROVIDER_ENV_VARS)) {
-		const value = process.env[envVar];
-		if (value) {
-			keys[provider] = value;
-		}
-	}
-	return createInMemoryAuthStorage(keys);
-}
-
-/**
  * Resolve a Model<Api> from CLI --provider and --model flags.
  *
  * Exits the process with an error message if the combination is invalid.
- * Returns undefined when neither flag is provided (session will be modelless).
  */
-function resolveModelFromArgs(
-	provider: string | undefined,
-	modelId: string | undefined,
-	authStorage: AuthStorage,
-) {
-	if (provider && modelId) {
-		const registry = new ModelRegistry(authStorage);
-		const model = registry.find(provider, modelId);
-		if (!model) {
-			console.error(`Error: model "${provider}/${modelId}" not found.`);
-			console.error("Check --provider and --model values, or omit them to use the default.");
-			process.exit(1);
-		}
-		return model;
-	}
-	if (provider || modelId) {
-		console.error("Error: --provider and --model must be specified together.");
+function resolveModelFromArgs(provider: string, modelId: string, authStorage: AuthStorage) {
+	const registry = new ModelRegistry(authStorage);
+	const model = registry.find(provider, modelId);
+	if (!model) {
+		console.error(`Error: model "${provider}/${modelId}" not found.`);
+		console.error("Check --provider and --model values.");
 		process.exit(1);
 	}
-	return undefined;
+	return model;
 }
 
 export async function main(argv: string[]): Promise<void> {
@@ -78,7 +34,9 @@ export async function main(argv: string[]): Promise<void> {
 		process.exit(0);
 	}
 
-	const authStorage = buildAuthStorageFromEnv();
+	const apiKeyOverride = args.apiKey ? { provider: args.provider, apiKey: args.apiKey } : undefined;
+
+	const authStorage = buildAuthStorageFromEnv(apiKeyOverride);
 
 	// Resolve the model from CLI flags before creating the session.
 	// We need a temporary ModelRegistry here because createRpcSession requires a


### PR DESCRIPTION
## Summary

- Add optional `--api-key <key>` CLI flag that injects an API key into `InMemoryAuthStorage`, overriding any environment variable for the same provider
- Make `--provider` and `--model` required flags (previously optional, allowing modelless sessions). `--help` and `--version` still work without them
- Extract `buildAuthStorageFromEnv` into `auth.ts` for testability with full unit test coverage

Closes #58

## Changes

**`packages/otter-agent-cli/src/args.ts`**
- Added `--api-key <key>` parse option and `apiKey` field to `ParsedArgs`
- Made `--provider` and `--model` required (validation exits with error if missing)
- `--help` and `--version` short-circuit before validation
- Updated help text

**`packages/otter-agent-cli/src/auth.ts`** (new)
- Extracted `PROVIDER_ENV_VARS` map and `buildAuthStorageFromEnv()` from `main.ts`
- `buildAuthStorageFromEnv()` accepts an optional `{ provider, apiKey }` override merged after env vars

**`packages/otter-agent-cli/src/main.ts`**
- Simplified `resolveModelFromArgs()` — both args guaranteed to be present
- Wired `args.apiKey` through to the auth storage builder

**`packages/otter-agent-cli/src/auth.test.ts`** (new)
- 5 tests: env var reading, undefined for missing env vars, override precedence, override adds new key, empty storage

**`packages/otter-agent-cli/src/args.test.ts`**
- Updated all tests for required provider/model
- Added subprocess tests for missing provider/model validation
- Added tests for `--api-key` parsing

## Test results
- 359 tests pass (334 core + 25 cli), 0 failures
- No lint errors in changed files
- Clean build

## Code reviews
- [First review](https://github.com/BowerJames/OtterAgent/issues/58#issuecomment-4195334518) — approved
- [Second review](https://github.com/BowerJames/OtterAgent/issues/58#issuecomment-4195377489) — approved