### PR TITLE
feat: add graceful shutdown to CLI RPC mode

### DIFF
--- a/packages/otter-agent-cli/src/rpc/rpc-mode.ts
+++ b/packages/otter-agent-cli/src/rpc/rpc-mode.ts
@@ -7,16 +7,37 @@ import { StdioTransport } from "./stdio-transport.js";
  *
  * Creates a StdioTransport, uses `createRpcSession()` to wire the session
  * and handler together with the UIProvider baked in at construction, then
- * blocks forever — the process exits only when killed externally.
+ * blocks until a graceful shutdown is triggered (via RPC command, stdin
+ * close, or SIGTERM/SIGINT signal).
  */
 export async function runRpcMode(
 	options: Omit<CreateRpcSessionOptions, "transport">,
 ): Promise<void> {
-	const transport = new StdioTransport();
-	const { handler } = await createRpcSession({ transport, ...options });
+	// Mutable ref so the StdioTransport callback can trigger shutdown
+	// on the handler that is created after the transport.
+	const ref = { handler: null as unknown as { requestShutdown(): void } };
 
+	const transport = new StdioTransport(() => ref.handler.requestShutdown());
+
+	let resolveShutdown: () => void;
+	const shutdownPromise = new Promise<void>((resolve) => {
+		resolveShutdown = resolve;
+	});
+
+	const { handler } = await createRpcSession({
+		transport,
+		...options,
+		onShutdown: () => resolveShutdown(),
+	});
+	ref.handler = handler;
 	handler.start();
 
-	// Block forever — RPC mode runs until the process is killed.
-	return new Promise(() => {});
+	// Signal handlers for graceful shutdown
+	const shutdown = () => handler.requestShutdown();
+	process.on("SIGTERM", shutdown);
+	process.on("SIGINT", shutdown);
+
+	await shutdownPromise;
+	// Graceful shutdown complete — exit cleanly
+	process.exit(0);
 }

--- a/packages/otter-agent-cli/src/rpc/stdio-transport.ts
+++ b/packages/otter-agent-cli/src/rpc/stdio-transport.ts
@@ -13,11 +13,15 @@ import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
  */
 export class StdioTransport implements RpcTransport {
 	private _detachReader: (() => void) | undefined;
+	private _detachStdinEnd: (() => void) | undefined;
 	private _originalConsoleLog: typeof console.log;
 	private _originalConsoleWarn: typeof console.warn;
 	private _originalConsoleInfo: typeof console.info;
+	private readonly _onStdinClose?: () => void;
 
-	constructor() {
+	constructor(onStdinClose?: () => void) {
+		this._onStdinClose = onStdinClose;
+
 		// Redirect console methods to stderr to protect the JSONL stream.
 		this._originalConsoleLog = console.log;
 		this._originalConsoleWarn = console.warn;
@@ -34,11 +38,19 @@ export class StdioTransport implements RpcTransport {
 			try {
 				parsed = JSON.parse(line);
 			} catch {
-				// Silently discard malformed lines — callers can't recover from parse errors.
+				// Silently discard malformed lines
 				return;
 			}
 			handler(parsed as RpcInboundMessage);
 		});
+
+		const onEnd = (): void => {
+			this._onStdinClose?.();
+		};
+		process.stdin.on("end", onEnd);
+		this._detachStdinEnd = () => {
+			process.stdin.off("end", onEnd);
+		};
 	}
 
 	send(message: RpcOutboundMessage): void {
@@ -48,6 +60,8 @@ export class StdioTransport implements RpcTransport {
 	close(): void {
 		this._detachReader?.();
 		this._detachReader = undefined;
+		this._detachStdinEnd?.();
+		this._detachStdinEnd = undefined;
 
 		// Restore console methods.
 		console.log = this._originalConsoleLog;

--- a/packages/otter-agent/src/rpc/create-rpc-session.test.ts
+++ b/packages/otter-agent/src/rpc/create-rpc-session.test.ts
@@ -224,4 +224,22 @@ describe("createRpcSession", () => {
 
 		expect(session.sessionManager).toBe(sessionManager);
 	});
+
+	test("onShutdown is threaded through to handler", async () => {
+		const transport = createMockTransport();
+		const onShutdown = mock(() => {});
+
+		const { handler } = await createRpcSession({
+			transport,
+			environment: createMockEnvironment(),
+			systemPrompt: "Test prompt",
+			onShutdown,
+		});
+
+		handler.start();
+		handler.requestShutdown();
+		await new Promise((r) => setTimeout(r, 50));
+
+		expect(onShutdown).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/otter-agent/src/rpc/create-rpc-session.ts
+++ b/packages/otter-agent/src/rpc/create-rpc-session.ts
@@ -63,6 +63,9 @@ export interface CreateRpcSessionOptions {
 
 	/** Additional pi-agent-core Agent options. */
 	agentOptions?: Partial<AgentOptions>;
+
+	/** Called when graceful shutdown completes. */
+	onShutdown?: () => void;
 }
 
 /** Result of {@link createRpcSession}. */
@@ -107,6 +110,7 @@ export async function createRpcSession(
 		transport,
 		resolveUIResponse: resolveResponse,
 		rejectAllUI: rejectAll,
+		onShutdown: options.onShutdown,
 	});
 
 	return { session, handler };

--- a/packages/otter-agent/src/rpc/index.ts
+++ b/packages/otter-agent/src/rpc/index.ts
@@ -10,6 +10,7 @@ export type {
 	RpcCommandType,
 	SetModelCommand,
 	SetThinkingLevelCommand,
+	ShutdownCommand,
 	SteerCommand,
 	// Responses
 	RpcErrorResponse,

--- a/packages/otter-agent/src/rpc/rpc-handler.test.ts
+++ b/packages/otter-agent/src/rpc/rpc-handler.test.ts
@@ -275,16 +275,34 @@ describe("RpcHandler", () => {
 		expect(transport.close).toHaveBeenCalled();
 	});
 
-	test("deferred shutdown stops after next command", async () => {
-		const { transport, handler } = createTestSetup();
+	test("deferred shutdown triggers graceful shutdown after next command", async () => {
+		const onShutdown = mock(() => {});
+		const transport = createMockTransport();
+		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test prompt",
+			uiProvider,
+		});
+		const handler = new RpcHandler({
+			session,
+			transport,
+			resolveUIResponse: resolveResponse,
+			rejectAllUI: rejectAll,
+			onShutdown,
+		});
+		handler.start();
 
 		handler.requestShutdown();
 
-		// Next command should trigger stop
+		// Next command should trigger graceful shutdown
 		transport.inject({ type: "abort", id: "req_7" });
-		await new Promise((r) => setTimeout(r, 10));
+		await new Promise((r) => setTimeout(r, 50));
 
 		expect(transport.close).toHaveBeenCalled();
+		expect(onShutdown).toHaveBeenCalledTimes(1);
 	});
 
 	test("steer sends user message to session", async () => {
@@ -432,6 +450,141 @@ describe("RpcHandler", () => {
 		expect(responses[0].error).toContain("Missing required field");
 
 		handler.stop();
+	});
+});
+
+describe("RpcHandler graceful shutdown", () => {
+	test("shutdown command responds with success after shutdown completes", async () => {
+		const onShutdown = mock(() => {});
+		const transport = createMockTransport();
+		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test prompt",
+			uiProvider,
+		});
+		const handler = new RpcHandler({
+			session,
+			transport,
+			resolveUIResponse: resolveResponse,
+			rejectAllUI: rejectAll,
+			onShutdown,
+		});
+		handler.start();
+
+		transport.inject({ type: "shutdown", id: "req_shut" });
+		await new Promise((r) => setTimeout(r, 50));
+
+		const responses = getResponses(transport);
+		const shutdownResponse = responses.find((r) => r.command === "shutdown");
+		expect(shutdownResponse).toBeDefined();
+		expect(shutdownResponse?.success).toBe(true);
+		expect(shutdownResponse?.id).toBe("req_shut");
+
+		// onShutdown should have been called
+		expect(onShutdown).toHaveBeenCalledTimes(1);
+	});
+
+	test("shutdown triggers dispose, stop, and onShutdown", async () => {
+		const onShutdown = mock(() => {});
+		const transport = createMockTransport();
+		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
+		const rejectAllSpy = mock((_reason: string) => rejectAll(_reason));
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test prompt",
+			uiProvider,
+		});
+
+		const handler = new RpcHandler({
+			session,
+			transport,
+			resolveUIResponse: resolveResponse,
+			rejectAllUI: rejectAllSpy,
+			onShutdown,
+		});
+		handler.start();
+
+		transport.inject({ type: "shutdown", id: "req_order" });
+		await new Promise((r) => setTimeout(r, 50));
+
+		// Verify dispose was called (via _performGracefulShutdown)
+		expect(onShutdown).toHaveBeenCalledTimes(1);
+		// Verify transport was closed (via stop())
+		expect(transport.close).toHaveBeenCalled();
+		// Verify rejectAllUI was called (via stop())
+		expect(rejectAllSpy).toHaveBeenCalledWith("RPC handler stopped");
+	});
+
+	test("onShutdown is called after the shutdown command response is sent", async () => {
+		const order: string[] = [];
+		const onShutdown = mock(() => {
+			order.push("onShutdown");
+		});
+		const transport = createMockTransport();
+		const origSend = transport.send.bind(transport);
+		transport.send = (message) => {
+			if ((message as { command?: string }).command === "shutdown") {
+				order.push("response");
+			}
+			origSend(message);
+		};
+		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test prompt",
+			uiProvider,
+		});
+		const handler = new RpcHandler({
+			session,
+			transport,
+			resolveUIResponse: resolveResponse,
+			rejectAllUI: rejectAll,
+			onShutdown,
+		});
+		handler.start();
+
+		transport.inject({ type: "shutdown", id: "req_timing" });
+		await new Promise((r) => setTimeout(r, 50));
+
+		expect(order).toEqual(["response", "onShutdown"]);
+	});
+
+	test("requestShutdown is idempotent", async () => {
+		const onShutdown = mock(() => {});
+		const transport = createMockTransport();
+		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
+		const session = new AgentSession({
+			sessionManager: createMockSessionManager(),
+			authStorage: createMockAuthStorage(),
+			environment: createMockEnvironment(),
+			systemPrompt: "Test prompt",
+			uiProvider,
+		});
+		const handler = new RpcHandler({
+			session,
+			transport,
+			resolveUIResponse: resolveResponse,
+			rejectAllUI: rejectAll,
+			onShutdown,
+		});
+		handler.start();
+
+		handler.requestShutdown();
+		handler.requestShutdown();
+		handler.requestShutdown();
+
+		await new Promise((r) => setTimeout(r, 50));
+
+		// onShutdown should only be called once
+		expect(onShutdown).toHaveBeenCalledTimes(1);
+		expect(transport.close).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/otter-agent/src/rpc/rpc-handler.ts
+++ b/packages/otter-agent/src/rpc/rpc-handler.ts
@@ -7,7 +7,7 @@
  * - All other commands are awaited before responding
  * - Events are forwarded 1:1 from session to transport
  * - Extension UI responses are routed to the RPC UIProvider
- * - Shutdown is deferred (flag checked after each command)
+ * - Shutdown triggers a graceful sequence: abort → waitForIdle → dispose → stop
  */
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session.js";
 import type {
@@ -20,6 +20,9 @@ import type {
 	RpcTransport,
 } from "./types.js";
 
+/** Maximum time to wait for the agent to settle during graceful shutdown (ms). */
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 120_000;
+
 export interface RpcHandlerOptions {
 	session: AgentSession;
 	transport: RpcTransport;
@@ -27,6 +30,8 @@ export interface RpcHandlerOptions {
 	resolveUIResponse: (response: ExtensionUIResponse) => void;
 	/** Rejects all pending extension UI requests (used during shutdown). */
 	rejectAllUI: (reason: string) => void;
+	/** Called when graceful shutdown completes (after abort → idle → dispose → stop). */
+	onShutdown?: () => void;
 }
 
 export class RpcHandler {
@@ -34,8 +39,14 @@ export class RpcHandler {
 	private readonly _transport: RpcTransport;
 	private readonly _resolveUIResponse: (response: ExtensionUIResponse) => void;
 	private readonly _rejectAllUI: (reason: string) => void;
+	private readonly _onShutdown?: () => void;
 	private _unsubscribeSession: (() => void) | undefined;
 	private _shutdownRequested = false;
+	private _shutdownInProgress = false;
+	private _resolveShutdown: (() => void) | undefined;
+	private _shutdownPromise: Promise<void> | undefined;
+	private _shutdownTimer: ReturnType<typeof setTimeout> | undefined;
+	private _waitForIdleTimer: ReturnType<typeof setTimeout> | undefined;
 	private _lastState: RpcSessionState | undefined;
 
 	constructor(options: RpcHandlerOptions) {
@@ -43,6 +54,7 @@ export class RpcHandler {
 		this._transport = options.transport;
 		this._resolveUIResponse = options.resolveUIResponse;
 		this._rejectAllUI = options.rejectAllUI;
+		this._onShutdown = options.onShutdown;
 	}
 
 	/** Start listening for commands and forwarding events. */
@@ -209,6 +221,14 @@ export class RpcHandler {
 				break;
 			}
 
+			case "shutdown": {
+				this.requestShutdown();
+				// Wait for the graceful shutdown sequence to complete before responding.
+				await this._shutdownPromise;
+				this._send(this._success(command.id, "shutdown"));
+				break;
+			}
+
 			default: {
 				// Try extension command registry before returning error
 				await this._tryExtensionCommand(command);
@@ -236,15 +256,99 @@ export class RpcHandler {
 
 	// ─── Shutdown ────────────────────────────────────────────────────
 
-	/** Request deferred shutdown (checked after each command). */
+	/** Request graceful shutdown (abort → idle → dispose → stop). */
 	requestShutdown(): void {
+		if (this._shutdownRequested) return;
 		this._shutdownRequested = true;
+		this._shutdownPromise = new Promise<void>((resolve) => {
+			this._resolveShutdown = resolve;
+		});
+		this._shutdownTimer = setTimeout(() => this._onShutdownTimeout(), GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+		this._checkShutdown();
+	}
+
+	private _onShutdownTimeout(): void {
+		// If shutdown is still in progress after the timeout, force cleanup.
+		// This should not normally happen since _performGracefulShutdown has
+		// its own per-step timeout, but serves as a last-resort safety net.
+		if (this._shutdownInProgress) {
+			this.stop();
+			this._onShutdown?.();
+			this._resolveShutdown?.();
+		}
 	}
 
 	private _checkShutdown(): void {
-		if (this._shutdownRequested) {
-			this.stop();
+		if (this._shutdownRequested && !this._shutdownInProgress) {
+			this._shutdownInProgress = true;
+			this._performGracefulShutdown().catch(() => {
+				// If graceful shutdown fails (e.g., waitForIdle rejects),
+				// force cleanup anyway.
+				clearTimeout(this._waitForIdleTimer);
+				clearTimeout(this._shutdownTimer);
+				this.stop();
+				this._onShutdown?.();
+				this._resolveShutdown?.();
+			});
 		}
+	}
+
+	/**
+	 * Perform the graceful shutdown sequence:
+	 * 1. Abort any in-flight agent turn
+	 * 2. Wait for the agent to settle (with timeout safety net)
+	 * 3. Dispose the session (fires session_shutdown event for extensions)
+	 * 4. Resolve the shutdown promise (unblocks awaiting command handler)
+	 * 5. Clean up transport and reject pending UI (after response is sent)
+	 * 6. Notify the caller (may trigger process.exit in CLI mode)
+	 */
+	private async _performGracefulShutdown(): Promise<void> {
+		// 1. Abort any in-flight agent turn
+		if (this._session.agent.state.isStreaming) {
+			this._session.abort();
+		}
+
+		// 2. Wait for the agent to settle (with timeout safety net)
+		const idlePromise = this._session.waitForIdle().then(
+			() => {
+				clearTimeout(this._waitForIdleTimer);
+				this._waitForIdleTimer = undefined;
+			},
+			() => {
+				clearTimeout(this._waitForIdleTimer);
+				this._waitForIdleTimer = undefined;
+			},
+		);
+		const timeoutPromise = new Promise<void>((_, reject) => {
+			this._waitForIdleTimer = setTimeout(
+				() => reject(new Error("Graceful shutdown timed out")),
+				GRACEFUL_SHUTDOWN_TIMEOUT_MS,
+			);
+		});
+		await Promise.race([idlePromise, timeoutPromise]).catch(() => {
+			// Timeout or error — proceed with cleanup anyway
+		});
+
+		// 3. Dispose the session (fires session_shutdown event for extensions)
+		await this._session.dispose();
+
+		// 4. Clear timers and resolve the shutdown promise so the awaiting
+		//    command handler can send its response.
+		clearTimeout(this._shutdownTimer);
+		this._shutdownTimer = undefined;
+		clearTimeout(this._waitForIdleTimer);
+		this._waitForIdleTimer = undefined;
+		this._resolveShutdown?.();
+
+		// 5. Wait a microtask tick so the command handler can send the
+		//    shutdown response before we close the transport.
+		await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+		// 6. Clean up transport and reject pending UI
+		this.stop();
+
+		// 7. Notify the caller (may trigger process.exit in CLI mode)
+		this._onShutdown?.();
 	}
 
 	// ─── State Change Detection ─────────────────────────────────────

--- a/packages/otter-agent/src/rpc/types.ts
+++ b/packages/otter-agent/src/rpc/types.ts
@@ -74,6 +74,12 @@ export interface GetCommandsCommand {
 	id?: string;
 }
 
+/** Lifecycle commands. */
+export interface ShutdownCommand {
+	type: "shutdown";
+	id?: string;
+}
+
 /** Union of all RPC commands. */
 export type RpcCommand =
 	| PromptCommand
@@ -84,7 +90,8 @@ export type RpcCommand =
 	| SetThinkingLevelCommand
 	| CompactCommand
 	| GetStateCommand
-	| GetCommandsCommand;
+	| GetCommandsCommand
+	| ShutdownCommand;
 
 /** String literal union of all command types. */
 export type RpcCommandType = RpcCommand["type"];


### PR DESCRIPTION
## Summary

Closes #52

Adds graceful shutdown to the CLI RPC mode so the process can shut down cleanly instead of blocking forever. Three shutdown triggers are supported:

1. ** RPC command** — client sends , receives a success response after cleanup completes
2. **stdin EOF** — when the client closes the pipe, the agent shuts down automatically
3. **SIGTERM / SIGINT** — OS signals trigger graceful shutdown

## Shutdown sequence

```
abort (if streaming) → waitForIdle (120s timeout) → session.dispose →
resolve promise (response sent) → stop (close transport) → onShutdown (exit)
``

The success response is sent **after** the graceful shutdown sequence completes (not fire-and-forget), giving the client confirmation that cleanup is done.

## Changes

| File | Change |
|---|---|
| `packages/otter-agent/src/rpc/types.ts` | Add `ShutdownCommand` interface + union member |
| `packages/otter-agent/src/rpc/index.ts` | Export `ShutdownCommand` |
| `packages/otter-agent/src/rpc/rpc-handler.ts` | Upgrade `requestShutdown()` to async graceful sequence with timeout safety net, add `shutdown` command handler, add `onShutdown` callback |
| `packages/otter-agent/src/rpc/create-rpc-session.ts` | Thread `onShutdown` option through to handler |
| `packages/otter-agent-cli/src/rpc/stdio-transport.ts` | Add `onStdinClose` callback wired to stdin `end` event |
| `packages/otter-agent-cli/src/rpc/rpc-mode.ts` | Wire stdin close + SIGTERM/SIGINT → `requestShutdown()`, await shutdown promise, `process.exit(0)` |
| `packages/otter-agent/src/rpc/rpc-handler.test.ts` | Update 1 test + add 4 new shutdown tests |
| `packages/otter-agent/src/rpc/create-rpc-session.test.ts` | Add `onShutdown` passthrough test |

## Test results

- **364/364 tests pass** (339 core + 25 CLI)
- **Build** clean
- **Lint** clean (no new issues)
- **Code review** passed (2 rounds, all findings addressed)