### PR TITLE
feat: add RPC REPL script for multi-turn conversation testing

### DIFF
--- a/scripts/rpc-repl.ts
+++ b/scripts/rpc-repl.ts
@@ -481,7 +481,11 @@ async function main(): Promise<void> {
 
 	function sendCommand(cmd: Record<string, unknown>): void {
 		const line = `${JSON.stringify(cmd)}\n`;
-		child.stdin?.write(line);
+		try {
+			child.stdin?.write(line);
+		} catch {
+			// stdin may have been destroyed during shutdown
+		}
 	}
 
 	// ─── REPL readline ────────────────────────────────────────────
@@ -555,7 +559,14 @@ async function main(): Promise<void> {
 		process.exit(1);
 	});
 
-	// ─── Ctrl+C handling (two strikes) ────────────────────────────
+	// ─── Ctrl+C and Ctrl+D handling ───────────────────────────────
+
+	rl.on("close", () => {
+		// Ctrl+D (EOF) — send graceful shutdown if not already sent
+		if (!shutdownSent && child.exitCode === null) {
+			sendCommand({ type: "shutdown", id: "repl_eof" });
+		}
+	});
 
 	process.on("SIGINT", () => {
 		if (child.exitCode !== null) {


### PR DESCRIPTION
## Summary

Adds `scripts/rpc-repl.ts` — an interactive developer tool that spawns the `otter` CLI binary and provides a terminal REPL for multi-turn conversations with a real LLM over the JSONL RPC protocol.

Closes #61

## Usage

```bash
bun run build
bun scripts/rpc-repl.ts --provider anthropic --model claude-sonnet-4-20250514
bun scripts/rpc-repl.ts --provider anthropic --model claude-sonnet-4-20250514 --show-events message_update
```

## Features

- **Configurable** — all otter CLI flags supported (`--provider`, `--model`, `--api-key`, `--thinking`, `--system-prompt`, `--cwd`)
- **Interactive REPL** — `>` prompt when idle, streams assistant text incrementally
- **Tool call display** — yellow for calls, dim for results, red for errors
- **REPL slash commands** — `/help`, `/state`, `/commands`, `/shutdown`
- **Event filtering** — `--show-events` flag to whitelist which events are displayed
- **Extension UI handling** — confirm, input, select, dialog, notify all handled interactively in the terminal
- **Graceful shutdown** — Ctrl+C sends shutdown, second Ctrl+C force-kills, Ctrl+D sends shutdown, 10s safety timeout
- **Zero dependencies** — Node `child_process` + `readline` only

## Review history

3 rounds of independent code review via pi-coding-agent. All critical and minor issues resolved:

- Text streaming reads `delta` as a string from the discriminated union (`text_delta`/`thinking_delta`)
- Select UI response sends 0-based numeric index matching `RpcUIProvider` expectations
- Dialog UI handler sends response to prevent agent hangs
- Two-strike Ctrl+C uses separate `shutdownSent` flag
- Ctrl+D (EOF) sends graceful shutdown
- Stdin writes wrapped in try/catch for shutdown safety

## Checks

- Lint: ✅ clean
- Tests: ✅ all 364 pass
- Build: ✅ clean