### PR TITLE
feat: unify SessionManager Entry type across implementations

### DIFF
--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -1,5 +1,6 @@
 // OtterAgent interfaces
 export type {
+	Entry,
 	EntryId,
 	ExtensionTemplate,
 	ReadonlySessionManager,

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -1,6 +1,7 @@
 export type { AgentEnvironment } from "./agent-environment.js";
 export type { AuthStorage } from "./auth-storage.js";
 export type {
+	Entry,
 	SessionContext,
 	SessionManager,
 	ReadonlySessionManager,

--- a/packages/otter-agent/src/interfaces/session-manager.ts
+++ b/packages/otter-agent/src/interfaces/session-manager.ts
@@ -7,6 +7,42 @@ import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
 export type EntryId = string;
 
 /**
+ * Unified entry type for session storage.
+ *
+ * A discriminated union representing all possible entry kinds that can be
+ * stored by a {@link SessionManager} implementation. Every entry carries a
+ * unique {@link EntryId} and a `type` discriminator.
+ */
+export type Entry =
+	| { type: "message"; id: EntryId; message: AgentMessage }
+	| {
+			type: "customMessage";
+			id: EntryId;
+			customType: string;
+			content: string | (TextContent | ImageContent)[];
+			display: boolean;
+			details?: unknown;
+			timestamp: number;
+	  }
+	| { type: "customEntry"; id: EntryId; customType: string; data?: unknown }
+	| {
+			type: "modelChange";
+			id: EntryId;
+			model: { provider: string; modelId: string };
+			thinkingLevel: string;
+	  }
+	| { type: "thinkingLevelChange"; id: EntryId; thinkingLevel: string }
+	| {
+			type: "compaction";
+			id: EntryId;
+			summary: string;
+			firstKeptEntryId: EntryId;
+			tokensBefore: number;
+			details?: unknown;
+	  }
+	| { type: "label"; id: EntryId; label: string; targetEntryId: EntryId };
+
+/**
  * The result of building session context for the LLM.
  *
  * Contains the ordered message list along with the model and thinking

--- a/packages/otter-agent/src/session-managers/in-memory-session-manager.test.ts
+++ b/packages/otter-agent/src/session-managers/in-memory-session-manager.test.ts
@@ -101,6 +101,24 @@ describe("appendCustomMessageEntry", () => {
 		// @ts-expect-error — accessing custom role field
 		expect(messages[0].content).toEqual(content);
 	});
+
+	test("timestamp reflects creation time, not context-build time", async () => {
+		const sm = createInMemorySessionManager();
+
+		const beforeInsert = Date.now();
+		sm.appendCustomMessageEntry("ext-1", "original content", true);
+		const afterInsert = Date.now();
+
+		// Small delay to ensure buildSessionContext runs at a later time.
+		await Bun.sleep(10);
+
+		const { messages } = sm.buildSessionContext();
+		expect(messages).toHaveLength(1);
+		// @ts-expect-error — accessing custom role field
+		const timestamp = messages[0].timestamp as number;
+		expect(timestamp).toBeGreaterThanOrEqual(beforeInsert);
+		expect(timestamp).toBeLessThanOrEqual(afterInsert);
+	});
 });
 
 // ─── appendCustomEntry ────────────────────────────────────────────────────────

--- a/packages/otter-agent/src/session-managers/in-memory-session-manager.ts
+++ b/packages/otter-agent/src/session-managers/in-memory-session-manager.ts
@@ -1,38 +1,15 @@
 import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
-import type { EntryId, SessionContext, SessionManager } from "../interfaces/session-manager.js";
+import type {
+	Entry,
+	EntryId,
+	SessionContext,
+	SessionManager,
+} from "../interfaces/session-manager.js";
 import { createCompactionSummaryMessage, createCustomMessage } from "../session/messages.js";
 
-type InMemoryEntry =
-	| { type: "message"; id: EntryId; message: AgentMessage }
-	| {
-			type: "customMessage";
-			id: EntryId;
-			customType: string;
-			content: string | (TextContent | ImageContent)[];
-			display: boolean;
-			details?: unknown;
-	  }
-	| { type: "customEntry"; id: EntryId; customType: string; data?: unknown }
-	| {
-			type: "modelChange";
-			id: EntryId;
-			model: { provider: string; modelId: string };
-			thinkingLevel: string;
-	  }
-	| { type: "thinkingLevelChange"; id: EntryId; thinkingLevel: string }
-	| {
-			type: "compaction";
-			id: EntryId;
-			summary: string;
-			firstKeptEntryId: EntryId;
-			tokensBefore: number;
-			details?: unknown;
-	  }
-	| { type: "label"; id: EntryId; label: string; targetEntryId: EntryId };
-
 export class InMemorySessionManager implements SessionManager {
-	private readonly entries: InMemoryEntry[] = [];
+	private readonly entries: Entry[] = [];
 	private nextId = 1;
 
 	private generateId(): EntryId {
@@ -52,7 +29,15 @@ export class InMemorySessionManager implements SessionManager {
 		details?: unknown,
 	): EntryId {
 		const id = this.generateId();
-		this.entries.push({ type: "customMessage", id, customType, content, display, details });
+		this.entries.push({
+			type: "customMessage",
+			id,
+			customType,
+			content,
+			display,
+			details,
+			timestamp: Date.now(),
+		});
 		return id;
 	}
 
@@ -93,7 +78,7 @@ export class InMemorySessionManager implements SessionManager {
 
 	buildSessionContext(): SessionContext {
 		// Find the latest compaction entry.
-		let latestCompaction: Extract<InMemoryEntry, { type: "compaction" }> | undefined;
+		let latestCompaction: Extract<Entry, { type: "compaction" }> | undefined;
 		for (const entry of this.entries) {
 			if (entry.type === "compaction") {
 				latestCompaction = entry;
@@ -152,7 +137,7 @@ export class InMemorySessionManager implements SessionManager {
 		return { messages, thinkingLevel: thinkingLevel as ThinkingLevel, model };
 	}
 
-	private extractMessages(entries: InMemoryEntry[]): AgentMessage[] {
+	private extractMessages(entries: Entry[]): AgentMessage[] {
 		const messages: AgentMessage[] = [];
 		for (const entry of entries) {
 			if (entry.type === "message") {
@@ -164,7 +149,7 @@ export class InMemorySessionManager implements SessionManager {
 						entry.content,
 						entry.display,
 						entry.details,
-						Date.now(),
+						entry.timestamp,
 					),
 				);
 			}

--- a/packages/otter-agent/src/session-managers/sqlite-session-manager.ts
+++ b/packages/otter-agent/src/session-managers/sqlite-session-manager.ts
@@ -1,39 +1,13 @@
 import { Database } from "bun:sqlite";
 import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
-import type { EntryId, SessionContext, SessionManager } from "../interfaces/session-manager.js";
+import type {
+	Entry,
+	EntryId,
+	SessionContext,
+	SessionManager,
+} from "../interfaces/session-manager.js";
 import { createCompactionSummaryMessage, createCustomMessage } from "../session/messages.js";
-
-// ─── Entry types (mirrors InMemoryEntry) ─────────────────────────────────────
-
-type SqliteEntry =
-	| { type: "message"; id: EntryId; message: AgentMessage }
-	| {
-			type: "customMessage";
-			id: EntryId;
-			customType: string;
-			content: string | (TextContent | ImageContent)[];
-			display: boolean;
-			details?: unknown;
-			timestamp: number;
-	  }
-	| { type: "customEntry"; id: EntryId; customType: string; data?: unknown }
-	| {
-			type: "modelChange";
-			id: EntryId;
-			model: { provider: string; modelId: string };
-			thinkingLevel: string;
-	  }
-	| { type: "thinkingLevelChange"; id: EntryId; thinkingLevel: string }
-	| {
-			type: "compaction";
-			id: EntryId;
-			summary: string;
-			firstKeptEntryId: EntryId;
-			tokensBefore: number;
-			details?: unknown;
-	  }
-	| { type: "label"; id: EntryId; label: string; targetEntryId: EntryId };
 
 // ─── Options ─────────────────────────────────────────────────────────────────
 
@@ -156,7 +130,7 @@ export class SqliteSessionManager implements SessionManager {
 		return id;
 	}
 
-	private loadEntries(): SqliteEntry[] {
+	private loadEntries(): Entry[] {
 		this.assertNotClosed();
 		const rows = this.db
 			.prepare(
@@ -279,7 +253,7 @@ export class SqliteSessionManager implements SessionManager {
 		const entries = this.loadEntries();
 
 		// Find the latest compaction entry.
-		let latestCompaction: Extract<SqliteEntry, { type: "compaction" }> | undefined;
+		let latestCompaction: Extract<Entry, { type: "compaction" }> | undefined;
 		for (const entry of entries) {
 			if (entry.type === "compaction") {
 				latestCompaction = entry;
@@ -358,7 +332,7 @@ export class SqliteSessionManager implements SessionManager {
 
 // ─── Standalone extraction helper (avoids `this` binding in callbacks) ───────
 
-function extractMessages(entries: SqliteEntry[]): AgentMessage[] {
+function extractMessages(entries: Entry[]): AgentMessage[] {
 	const messages: AgentMessage[] = [];
 	for (const entry of entries) {
 		if (entry.type === "message") {


### PR DESCRIPTION
## Summary

Both  and  previously defined their own local entry types ( and ) that were near-identical discriminated unions. This introduces a single unified  type in the public interface that both implementations now use.

Also fixes a timestamp bug in  where  entries did not store a timestamp, causing  to use  at context-build time instead of the original creation time.

Closes #77

## Changes

| File | What changed |
|---|---|
| `src/interfaces/session-manager.ts` | Added unified `Entry` discriminated union type |
| `src/interfaces/index.ts` | Exported `Entry` |
| `src/index.ts` | Exported `Entry` from package root |
| `src/session-managers/in-memory-session-manager.ts` | Removed local `InMemoryEntry`, uses `Entry`, fixed timestamp bug |
| `src/session-managers/sqlite-session-manager.ts` | Removed local `SqliteEntry`, uses `Entry` |
| `src/session-managers/in-memory-session-manager.test.ts` | Added timestamp creation-time test |

## Verification

- ✅ All 515 tests pass (450 core + 65 CLI)
- ✅ No lint issues in changed files
- ✅ Clean build
- ✅ Independent code review passed ([review comment](https://github.com/BowerJames/OtterAgent/issues/77#issuecomment-4210308548))