### PR TITLE
feat: add getEntries() method to SessionManager interface

### DIFF
--- a/packages/otter-agent/src/interfaces/session-manager.ts
+++ b/packages/otter-agent/src/interfaces/session-manager.ts
@@ -180,6 +180,21 @@ export interface SessionManager {
 	 * @returns The unique ID of the label entry.
 	 */
 	appendLabel(label: string, targetEntryId: EntryId): EntryId;
+
+	/**
+	 * Return all entries for this session in append order.
+	 *
+	 * Unlike {@link buildSessionContext}, which filters and transforms entries
+	 * into LLM-ready messages, this returns every entry verbatim — including
+	 * metadata entries, custom entries, labels, and compaction markers.
+	 *
+	 * Useful for extensions that persist state via {@link appendCustomEntry}
+	 * and need to reconstruct it on reload.
+	 *
+	 * @returns A read-only snapshot of all entries. Callers must not mutate
+	 *   the returned array or its elements.
+	 */
+	getEntries(): Entry[];
 }
 
 /**
@@ -189,4 +204,4 @@ export interface SessionManager {
  * mutation of session state. Extensions should use the ExtensionsAPI
  * methods (sendMessage, appendEntry, etc.) to write to the session.
  */
-export type ReadonlySessionManager = Pick<SessionManager, "buildSessionContext">;
+export type ReadonlySessionManager = Pick<SessionManager, "buildSessionContext" | "getEntries">;

--- a/packages/otter-agent/src/session-managers/in-memory-session-manager.test.ts
+++ b/packages/otter-agent/src/session-managers/in-memory-session-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ReadonlySessionManager } from "../interfaces/session-manager.js";
 import { COMPACTION_SUMMARY_PREFIX, COMPACTION_SUMMARY_SUFFIX } from "../session/messages.js";
 import {
 	InMemorySessionManager,
@@ -367,6 +368,82 @@ describe("EntryId uniqueness", () => {
 		];
 		const unique = new Set(ids);
 		expect(unique.size).toBe(ids.length);
+	});
+});
+
+// ─── getEntries ──────────────────────────────────────────────────────────────
+
+describe("getEntries", () => {
+	test("returns an empty array for a new session", () => {
+		const sm = createInMemorySessionManager();
+		expect(sm.getEntries()).toEqual([]);
+	});
+
+	test("returns all entries in append order", () => {
+		const sm = createInMemorySessionManager();
+		const msgId = sm.appendMessage(makeUserMessage("hello"));
+		sm.appendCustomEntry("ext-1", { state: true });
+		sm.appendModelChange({ provider: "anthropic", modelId: "claude-opus" }, "high");
+		sm.appendThinkingLevelChange("off");
+		sm.compact("summary", msgId, 100);
+		sm.appendLabel("important", msgId);
+		sm.appendCustomMessageEntry("ext-2", "visible", true);
+
+		const entries = sm.getEntries();
+		expect(entries).toHaveLength(7);
+		expect(entries[0].type).toBe("message");
+		expect(entries[1].type).toBe("customEntry");
+		expect(entries[2].type).toBe("modelChange");
+		expect(entries[3].type).toBe("thinkingLevelChange");
+		expect(entries[4].type).toBe("compaction");
+		expect(entries[5].type).toBe("label");
+		expect(entries[6].type).toBe("customMessage");
+	});
+
+	test("returns a shallow copy — mutating the returned array does not affect internal state", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendMessage(makeUserMessage("keep"));
+		const entries = sm.getEntries();
+		entries.push({ type: "label", id: "fake", label: "injected", targetEntryId: "x" });
+		expect(sm.getEntries()).toHaveLength(1);
+	});
+
+	test("customEntry entries are included (unlike buildSessionContext messages)", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendMessage(makeUserMessage("visible"));
+		sm.appendCustomEntry("my-ext", { key: "value" });
+
+		const entries = sm.getEntries();
+		expect(entries).toHaveLength(2);
+		expect(entries[1].type).toBe("customEntry");
+		if (entries[1].type === "customEntry") {
+			expect(entries[1].customType).toBe("my-ext");
+			expect(entries[1].data).toEqual({ key: "value" });
+		}
+	});
+
+	test("entries remain accessible after compaction", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendMessage(makeUserMessage("old"));
+		const keepId = sm.appendMessage(makeUserMessage("keep"));
+		sm.compact("summary", keepId);
+
+		const entries = sm.getEntries();
+		// All 3 entries still present: 2 messages + 1 compaction
+		expect(entries).toHaveLength(3);
+		expect(entries[0].type).toBe("message");
+		expect(entries[1].type).toBe("message");
+		expect(entries[2].type).toBe("compaction");
+	});
+
+	test("available via ReadonlySessionManager", () => {
+		const sm = createInMemorySessionManager();
+		sm.appendCustomEntry("ext", { persisted: true });
+
+		const readonly: ReadonlySessionManager = sm;
+		const entries = readonly.getEntries();
+		expect(entries).toHaveLength(1);
+		expect(entries[0].type).toBe("customEntry");
 	});
 });
 

--- a/packages/otter-agent/src/session-managers/in-memory-session-manager.ts
+++ b/packages/otter-agent/src/session-managers/in-memory-session-manager.ts
@@ -76,6 +76,10 @@ export class InMemorySessionManager implements SessionManager {
 		return id;
 	}
 
+	getEntries(): Entry[] {
+		return [...this.entries];
+	}
+
 	buildSessionContext(): SessionContext {
 		// Find the latest compaction entry.
 		let latestCompaction: Extract<Entry, { type: "compaction" }> | undefined;

--- a/packages/otter-agent/src/session-managers/sqlite-session-manager.test.ts
+++ b/packages/otter-agent/src/session-managers/sqlite-session-manager.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ReadonlySessionManager } from "../interfaces/session-manager.js";
 import { SessionManager } from "./index.js";
 import { SqliteSessionManager, createSqliteSessionManager } from "./sqlite-session-manager.js";
 
@@ -414,6 +415,107 @@ describe("SessionManager.sqlite()", () => {
 		expect(typeof sm2.appendMessage).toBe("function");
 		sm1.close();
 		sm2.close();
+	});
+});
+
+// ─── getEntries ──────────────────────────────────────────────────────────────
+
+describe("getEntries", () => {
+	test("returns an empty array for a new session", () => {
+		const sm = createSm();
+		expect(sm.getEntries()).toEqual([]);
+		sm.close();
+	});
+
+	test("returns all entries in append order", () => {
+		const sm = createSm();
+		const msgId = sm.appendMessage(makeUserMessage("hello"));
+		sm.appendCustomEntry("ext-1", { state: true });
+		sm.appendModelChange({ provider: "anthropic", modelId: "claude-opus" }, "high");
+		sm.appendThinkingLevelChange("off");
+		sm.compact("summary", msgId, 100);
+		sm.appendLabel("important", msgId);
+		sm.appendCustomMessageEntry("ext-2", "visible", true);
+
+		const entries = sm.getEntries();
+		expect(entries).toHaveLength(7);
+		expect(entries[0].type).toBe("message");
+		expect(entries[1].type).toBe("customEntry");
+		expect(entries[2].type).toBe("modelChange");
+		expect(entries[3].type).toBe("thinkingLevelChange");
+		expect(entries[4].type).toBe("compaction");
+		expect(entries[5].type).toBe("label");
+		expect(entries[6].type).toBe("customMessage");
+		sm.close();
+	});
+
+	test("entries persist across close/reopen", () => {
+		const path = dbPath();
+		const sessionId = "getEntries-persist";
+
+		const sm1 = new SqliteSessionManager({ dbPath: path, sessionId });
+		sm1.appendMessage(makeUserMessage("survives"));
+		sm1.appendCustomEntry("ext", { data: 42 });
+		sm1.close();
+
+		const sm2 = new SqliteSessionManager({ dbPath: path, sessionId });
+		const entries = sm2.getEntries();
+		expect(entries).toHaveLength(2);
+		expect(entries[0].type).toBe("message");
+		expect(entries[1].type).toBe("customEntry");
+		if (entries[1].type === "customEntry") {
+			expect(entries[1].data).toEqual({ data: 42 });
+		}
+		sm2.close();
+	});
+
+	test("customEntry entries are included", () => {
+		const sm = createSm();
+		sm.appendMessage(makeUserMessage("visible"));
+		sm.appendCustomEntry("my-ext", { key: "value" });
+
+		const entries = sm.getEntries();
+		expect(entries).toHaveLength(2);
+		expect(entries[1].type).toBe("customEntry");
+		if (entries[1].type === "customEntry") {
+			expect(entries[1].customType).toBe("my-ext");
+			expect(entries[1].data).toEqual({ key: "value" });
+		}
+		sm.close();
+	});
+
+	test("throws after close", () => {
+		const sm = createSm();
+		sm.close();
+		expect(() => sm.getEntries()).toThrow("closed");
+	});
+
+	test("session isolation — entries from one session do not leak", () => {
+		const path = dbPath();
+		const smA = new SqliteSessionManager({ dbPath: path, sessionId: "iso-A" });
+		const smB = new SqliteSessionManager({ dbPath: path, sessionId: "iso-B" });
+
+		smA.appendMessage(makeUserMessage("only in A"));
+		smB.appendMessage(makeUserMessage("only in B"));
+
+		expect(smA.getEntries()).toHaveLength(1);
+		expect(smA.getEntries()[0].type).toBe("message");
+		expect(smB.getEntries()).toHaveLength(1);
+		expect(smB.getEntries()[0].type).toBe("message");
+
+		smA.close();
+		smB.close();
+	});
+
+	test("available via ReadonlySessionManager", () => {
+		const sm = createSm();
+		sm.appendCustomEntry("ext", { persisted: true });
+
+		const readonly: ReadonlySessionManager = sm;
+		const entries = readonly.getEntries();
+		expect(entries).toHaveLength(1);
+		expect(entries[0].type).toBe("customEntry");
+		sm.close();
 	});
 });
 

--- a/packages/otter-agent/src/session-managers/sqlite-session-manager.ts
+++ b/packages/otter-agent/src/session-managers/sqlite-session-manager.ts
@@ -206,6 +206,10 @@ export class SqliteSessionManager implements SessionManager {
 		return this.insert({ type: "label", id, label, targetEntryId });
 	}
 
+	getEntries(): Entry[] {
+		return this.loadEntries();
+	}
+
 	buildSessionContext(): SessionContext {
 		this.assertNotClosed();
 		const entries = this.loadEntries();


### PR DESCRIPTION
## Summary

Add a `getEntries(): Entry[]` method to the `SessionManager` interface that returns all entries for the session in append order. Unlike `buildSessionContext()`, which filters and transforms entries into LLM-ready messages, this returns every entry verbatim — including metadata entries, custom entries, labels, and compaction markers.

Expose the method through `ReadonlySessionManager` so extensions can read the full session history. This enables extensions to persist state via `appendCustomEntry()` and reconstruct it later by scanning entries.

Closes #81

## Changes

- **Interface** (`src/interfaces/session-manager.ts`): Added `getEntries(): Entry[]` to `SessionManager`; widened `ReadonlySessionManager` Pick to include it.
- **InMemorySessionManager**: Returns a shallow copy (`[...this.entries]`).
- **SqliteSessionManager**: Delegates to existing `loadEntries()` private method.
- **Tests**: 12 new tests across both implementations covering empty sessions, ordering, copy semantics, customEntry inclusion, post-compaction access, persistence across close/reopen, close guard, session isolation, and ReadonlySessionManager access.

## Test Results

All 528 tests pass, build clean, no new lint issues introduced.

## Review

[Code review approved](https://github.com/BowerJames/OtterAgent/issues/81#issuecomment-4211799942) — no blocking issues found.