### PR TITLE
feat: add @otter-agent/extension-registry package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,14 @@
         "typescript": "^5.7.0",
       },
     },
+    "packages/extension-registry": {
+      "name": "@otter-agent/extension-registry",
+      "version": "0.0.1",
+      "dependencies": {
+        "@otter-agent/core": "workspace:*",
+        "@sinclair/typebox": "^0.34.0",
+      },
+    },
     "packages/otter-agent": {
       "name": "@otter-agent/core",
       "version": "0.0.1",
@@ -181,6 +189,8 @@
     "@otter-agent/cli": ["@otter-agent/cli@workspace:packages/otter-agent-cli"],
 
     "@otter-agent/core": ["@otter-agent/core@workspace:packages/otter-agent"],
+
+    "@otter-agent/extension-registry": ["@otter-agent/extension-registry@workspace:packages/extension-registry"],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 

--- a/packages/extension-registry/package.json
+++ b/packages/extension-registry/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "@otter-agent/extension-registry",
+	"version": "0.0.1",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc",
+		"test": "bun test",
+		"dev": "tsc --watch"
+	},
+	"dependencies": {
+		"@otter-agent/core": "workspace:*",
+		"@sinclair/typebox": "^0.34.0"
+	}
+}

--- a/packages/extension-registry/src/built-ins/context-injector/context-injector.test.ts
+++ b/packages/extension-registry/src/built-ins/context-injector/context-injector.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the ContextInjector built-in extension template.
+ */
+import { describe, expect, it } from "bun:test";
+import { validateExtensionConfig } from "@otter-agent/core";
+import {
+	type ContextInjectorConfig,
+	ContextInjectorConfigSchema,
+	ContextInjectorTemplate,
+} from "./context-injector.js";
+
+describe("ContextInjectorTemplate", () => {
+	it("has all required ExtensionTemplate methods", () => {
+		expect(typeof ContextInjectorTemplate.configSchema).toBe("function");
+		expect(typeof ContextInjectorTemplate.defaultConfig).toBe("function");
+		expect(typeof ContextInjectorTemplate.buildExtension).toBe("function");
+	});
+
+	it("returns a valid TypeBox schema from configSchema()", () => {
+		const schema = ContextInjectorTemplate.configSchema();
+		expect(schema).toBeDefined();
+		expect(ContextInjectorConfigSchema).toBe(schema);
+	});
+
+	it("returns correct defaults from defaultConfig()", () => {
+		const defaults = ContextInjectorTemplate.defaultConfig();
+		expect(defaults).toEqual({ content: "" });
+	});
+
+	it("builds an extension function", () => {
+		const extension = ContextInjectorTemplate.buildExtension({ content: "test" });
+		expect(typeof extension).toBe("function");
+	});
+
+	it("builds via validateExtensionConfig from core", () => {
+		const extension = validateExtensionConfig(ContextInjectorTemplate, {
+			content: "Always respond in French.",
+		});
+		expect(typeof extension).toBe("function");
+	});
+
+	it("the extension modifies the system prompt on before_agent_start", async () => {
+		let capturedSystemPrompt: string | undefined;
+
+		// Build a minimal fake ExtensionsAPI
+		const handlers = new Map<string, unknown>();
+		const api = {
+			on: (event: string, handler: unknown) => {
+				handlers.set(event, handler);
+			},
+		} as unknown as Parameters<ReturnType<typeof ContextInjectorTemplate.buildExtension>>[0];
+
+		// Build and invoke the extension
+		const extension = ContextInjectorTemplate.buildExtension({ content: "APPENDED TEXT" });
+		await extension(api);
+
+		// Simulate a before_agent_start event
+		const handler = handlers.get("before_agent_start") as (event: {
+			systemPrompt: string;
+			prompt: string;
+		}) => { systemPrompt?: string };
+		expect(typeof handler).toBe("function");
+
+		const result = handler({ systemPrompt: "Base prompt", prompt: "hello" });
+		expect(result).toEqual({ systemPrompt: "Base prompt\n\nAPPENDED TEXT" });
+	});
+
+	it("validates that invalid content type is rejected", () => {
+		// content must be a string — passing a number should fail validation
+		expect(() =>
+			validateExtensionConfig(ContextInjectorTemplate, { content: 42 as unknown as string }),
+		).toThrow("Extension config validation failed");
+	});
+
+	it("fills content from defaults when omitted", () => {
+		// No content provided — should use default "" and not throw
+		const extension = validateExtensionConfig(ContextInjectorTemplate, {});
+		expect(typeof extension).toBe("function");
+	});
+
+	it("accepts valid config", () => {
+		const extension = validateExtensionConfig(ContextInjectorTemplate, {
+			content: "Some context",
+		});
+		expect(typeof extension).toBe("function");
+	});
+});

--- a/packages/extension-registry/src/built-ins/context-injector/context-injector.ts
+++ b/packages/extension-registry/src/built-ins/context-injector/context-injector.ts
@@ -1,0 +1,49 @@
+import type { ExtensionTemplate } from "@otter-agent/core";
+/**
+ * Context Injector — built-in extension template that appends custom
+ * text to the system prompt on every agent turn.
+ *
+ * This serves as the canonical example of an ExtensionTemplate.
+ */
+import { Type } from "@sinclair/typebox";
+import type { Static } from "@sinclair/typebox";
+
+/**
+ * Config schema for the context-injector extension.
+ */
+export const ContextInjectorConfigSchema = Type.Object({
+	content: Type.String({
+		description: "Text to append to the system prompt on every turn.",
+	}),
+});
+
+/**
+ * Config type for the context-injector extension.
+ */
+export type ContextInjectorConfig = Static<typeof ContextInjectorConfigSchema>;
+
+/**
+ * Context Injector extension template.
+ *
+ * Appends the configured `content` to the system prompt on every
+ * `before_agent_start` event.
+ *
+ * @example
+ * ```ts
+ * import { validateExtensionConfig } from "@otter-agent/core";
+ * import { ContextInjectorTemplate } from "@otter-agent/extension-registry";
+ *
+ * const extension = validateExtensionConfig(ContextInjectorTemplate, {
+ *   content: "Always respond in French.",
+ * });
+ * ```
+ */
+export const ContextInjectorTemplate: ExtensionTemplate<typeof ContextInjectorConfigSchema> = {
+	configSchema: () => ContextInjectorConfigSchema,
+	defaultConfig: () => ({ content: "" }),
+	buildExtension: (config: ContextInjectorConfig) => (api) => {
+		api.on("before_agent_start", (event) => ({
+			systemPrompt: `${event.systemPrompt}\n\n${config.content}`,
+		}));
+	},
+};

--- a/packages/extension-registry/src/built-ins/context-injector/index.ts
+++ b/packages/extension-registry/src/built-ins/context-injector/index.ts
@@ -1,0 +1,5 @@
+export {
+	ContextInjectorTemplate,
+	ContextInjectorConfigSchema,
+} from "./context-injector.js";
+export type { ContextInjectorConfig } from "./context-injector.js";

--- a/packages/extension-registry/src/built-ins/index.ts
+++ b/packages/extension-registry/src/built-ins/index.ts
@@ -1,0 +1,5 @@
+export {
+	ContextInjectorTemplate,
+	ContextInjectorConfigSchema,
+} from "./context-injector/index.js";
+export type { ContextInjectorConfig } from "./context-injector/index.js";

--- a/packages/extension-registry/src/convenience.test.ts
+++ b/packages/extension-registry/src/convenience.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for convenience functions (buildExtension, isRegistered, getRegisteredNames).
+ *
+ * These test the public API directly rather than relying on indirect coverage
+ * via the default-registry tests. This catches regressions if convenience.ts
+ * is accidentally changed to delegate to a different registry instance.
+ */
+import { describe, expect, it } from "bun:test";
+import { buildExtension, getRegisteredNames, isRegistered } from "./convenience.js";
+
+describe("convenience functions", () => {
+	describe("isRegistered", () => {
+		it("returns true for a built-in template", () => {
+			expect(isRegistered("context-injector")).toBe(true);
+		});
+
+		it("returns false for an unknown name", () => {
+			expect(isRegistered("nonexistent")).toBe(false);
+		});
+	});
+
+	describe("getRegisteredNames", () => {
+		it("returns an array containing all built-in names", () => {
+			const names = getRegisteredNames();
+			expect(Array.isArray(names)).toBe(true);
+			expect(names).toContain("context-injector");
+		});
+
+		it("returns a copy (mutations do not affect the registry)", () => {
+			const names = getRegisteredNames();
+			names.push("injected");
+			expect(getRegisteredNames()).not.toContain("injected");
+		});
+	});
+
+	describe("buildExtension", () => {
+		it("builds a known template with config", () => {
+			const extension = buildExtension("context-injector", { content: "test" });
+			expect(typeof extension).toBe("function");
+		});
+
+		it("builds a known template without config", () => {
+			const extension = buildExtension("context-injector");
+			expect(typeof extension).toBe("function");
+		});
+
+		it("throws for an unknown name", () => {
+			expect(() => buildExtension("nonexistent")).toThrow(
+				'No extension template registered under "nonexistent"',
+			);
+		});
+
+		it("throws on invalid config", () => {
+			expect(() =>
+				buildExtension("context-injector", { content: 42 as unknown as string }),
+			).toThrow("Extension config validation failed");
+		});
+	});
+});

--- a/packages/extension-registry/src/convenience.ts
+++ b/packages/extension-registry/src/convenience.ts
@@ -1,0 +1,50 @@
+import type { Extension } from "@otter-agent/core";
+/**
+ * Convenience functions that delegate to the default registry.
+ *
+ * These provide the simplest API for consumers who don't need
+ * a custom registry instance.
+ */
+import { defaultRegistry } from "./default-registry.js";
+
+/**
+ * Build an extension from the default registry.
+ *
+ * @param name - The registered template name (e.g. "context-injector").
+ * @param config - Optional user-provided config. Deep-merged with the
+ *   template's defaults before validation.
+ * @returns A built Extension ready for use with AgentSession.
+ * @throws {ExtensionRegistryError} If no template is registered under the given name.
+ * @throws {ExtensionConfigValidationError} If config validation fails.
+ *
+ * @example
+ * ```ts
+ * import { buildExtension } from "@otter-agent/extension-registry";
+ *
+ * const extension = buildExtension("context-injector", {
+ *   content: "Always respond in French.",
+ * });
+ * ```
+ */
+export function buildExtension(name: string, config?: Record<string, unknown>): Extension {
+	return defaultRegistry.build(name, config);
+}
+
+/**
+ * Check if a name is registered in the default registry.
+ *
+ * @param name - The template name to check.
+ * @returns `true` if registered.
+ */
+export function isRegistered(name: string): boolean {
+	return defaultRegistry.has(name);
+}
+
+/**
+ * List all registered names in the default registry.
+ *
+ * @returns Array of registered names in insertion order.
+ */
+export function getRegisteredNames(): string[] {
+	return defaultRegistry.getRegisteredNames();
+}

--- a/packages/extension-registry/src/default-registry.test.ts
+++ b/packages/extension-registry/src/default-registry.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for the default registry.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+	ContextInjectorConfigSchema,
+	ContextInjectorTemplate,
+} from "./built-ins/context-injector/index.js";
+import { defaultRegistry } from "./default-registry.js";
+
+describe("defaultRegistry", () => {
+	it("has the context-injector built-in registered", () => {
+		expect(defaultRegistry.has("context-injector")).toBe(true);
+	});
+
+	it("returns the correct template for context-injector", () => {
+		const template = defaultRegistry.get("context-injector");
+		expect(template).toBe(ContextInjectorTemplate);
+	});
+
+	it("context-injector template has the correct schema", () => {
+		const template = defaultRegistry.get("context-injector");
+		expect(template?.configSchema()).toBe(ContextInjectorConfigSchema);
+	});
+
+	it("builds a working context-injector extension", () => {
+		const extension = defaultRegistry.build("context-injector", {
+			content: "Test context",
+		});
+		expect(typeof extension).toBe("function");
+	});
+
+	it("does not have unregistered names", () => {
+		expect(defaultRegistry.has("nonexistent")).toBe(false);
+	});
+
+	it("throws for unknown build", () => {
+		expect(() => defaultRegistry.build("nonexistent")).toThrow(
+			'No extension template registered under "nonexistent"',
+		);
+	});
+
+	it("lists registered names", () => {
+		const names = defaultRegistry.getRegisteredNames();
+		expect(names).toContain("context-injector");
+	});
+});

--- a/packages/extension-registry/src/default-registry.ts
+++ b/packages/extension-registry/src/default-registry.ts
@@ -1,0 +1,25 @@
+import { ContextInjectorTemplate } from "./built-ins/index.js";
+/**
+ * Default registry — pre-populated singleton with all built-in extension templates.
+ *
+ * Import {@link defaultRegistry} directly for advanced use, or use the
+ * convenience functions from `convenience.ts` for the common case.
+ */
+import { ExtensionRegistry } from "./registry.js";
+
+/**
+ * The default extension registry, pre-populated with all built-in templates.
+ *
+ * @example
+ * ```ts
+ * import { defaultRegistry } from "@otter-agent/extension-registry";
+ *
+ * const extension = defaultRegistry.build("context-injector", {
+ *   content: "Always respond in French.",
+ * });
+ * ```
+ */
+export const defaultRegistry = new ExtensionRegistry();
+
+// Register all built-in templates
+defaultRegistry.register("context-injector", ContextInjectorTemplate);

--- a/packages/extension-registry/src/index.ts
+++ b/packages/extension-registry/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @otter-agent/extension-registry
+ *
+ * A dynamic registry of named extension templates with a default
+ * pre-populated singleton and convenience functions.
+ */
+
+// Registry
+export { ExtensionRegistry, ExtensionRegistryError } from "./registry.js";
+
+// Default registry (pre-populated singleton)
+export { defaultRegistry } from "./default-registry.js";
+
+// Convenience functions (delegate to the default registry)
+export { buildExtension, getRegisteredNames, isRegistered } from "./convenience.js";
+
+// Built-in templates (also importable individually)
+export {
+	ContextInjectorTemplate,
+	ContextInjectorConfigSchema,
+} from "./built-ins/index.js";
+export type { ContextInjectorConfig } from "./built-ins/index.js";
+
+// Re-export core types consumers need
+export type { Extension, ExtensionTemplate } from "@otter-agent/core";
+export type { ExtensionConfigValidationError } from "@otter-agent/core";

--- a/packages/extension-registry/src/registry.test.ts
+++ b/packages/extension-registry/src/registry.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test";
+import { validateExtensionConfig } from "@otter-agent/core";
+/**
+ * Tests for ExtensionRegistry.
+ */
+import { Type } from "@sinclair/typebox";
+import { ExtensionRegistry, ExtensionRegistryError } from "./registry.js";
+
+// Minimal test template
+const TestConfigSchema = Type.Object({
+	enabled: Type.Boolean({ default: true }),
+	label: Type.String({ default: "test" }),
+});
+
+type TestConfig = { enabled: boolean; label: string };
+
+const testTemplate = {
+	configSchema: () => TestConfigSchema,
+	defaultConfig: (): TestConfig => ({ enabled: true, label: "test" }),
+	buildExtension: (config: TestConfig) => {
+		return () => {
+			// Extension captures config in closure — verified via build return
+			void config;
+		};
+	},
+};
+
+describe("ExtensionRegistry", () => {
+	describe("register", () => {
+		it("registers a template under a name", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("test", testTemplate);
+			expect(registry.has("test")).toBe(true);
+		});
+
+		it("throws on duplicate name", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("test", testTemplate);
+			expect(() => registry.register("test", testTemplate)).toThrow(ExtensionRegistryError);
+			expect(() => registry.register("test", testTemplate)).toThrow(
+				'template "test" is already registered',
+			);
+		});
+
+		it("allows different names", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("a", testTemplate);
+			registry.register("b", testTemplate);
+			expect(registry.has("a")).toBe(true);
+			expect(registry.has("b")).toBe(true);
+		});
+	});
+
+	describe("get", () => {
+		it("returns the registered template", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("test", testTemplate);
+			expect(registry.get("test")).toBe(testTemplate);
+		});
+
+		it("returns undefined for unknown name", () => {
+			const registry = new ExtensionRegistry();
+			expect(registry.get("unknown")).toBeUndefined();
+		});
+	});
+
+	describe("has", () => {
+		it("returns true for registered name", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("test", testTemplate);
+			expect(registry.has("test")).toBe(true);
+		});
+
+		it("returns false for unknown name", () => {
+			const registry = new ExtensionRegistry();
+			expect(registry.has("unknown")).toBe(false);
+		});
+
+		it("returns false for empty registry", () => {
+			const registry = new ExtensionRegistry();
+			expect(registry.has("anything")).toBe(false);
+		});
+	});
+
+	describe("getRegisteredNames", () => {
+		it("returns empty array for empty registry", () => {
+			const registry = new ExtensionRegistry();
+			expect(registry.getRegisteredNames()).toEqual([]);
+		});
+
+		it("returns all registered names in insertion order", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("first", testTemplate);
+			registry.register("second", testTemplate);
+			registry.register("third", testTemplate);
+			expect(registry.getRegisteredNames()).toEqual(["first", "second", "third"]);
+		});
+	});
+
+	describe("build", () => {
+		it("throws for unknown name", () => {
+			const registry = new ExtensionRegistry();
+			expect(() => registry.build("unknown")).toThrow(ExtensionRegistryError);
+			expect(() => registry.build("unknown")).toThrow(
+				'No extension template registered under "unknown"',
+			);
+		});
+
+		it("lists registered names in error message", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("known", testTemplate);
+			expect(() => registry.build("unknown")).toThrow(/Registered: known/);
+		});
+
+		it("builds with defaults when no config provided", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("test", testTemplate);
+			const extension = registry.build("test");
+			expect(typeof extension).toBe("function");
+		});
+
+		it("builds with merged config", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("test", testTemplate);
+			const extension = registry.build("test", { label: "custom" });
+			expect(typeof extension).toBe("function");
+		});
+
+		it("throws on invalid config", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("test", testTemplate);
+			// Pass a value that violates the schema (enabled should be boolean)
+			expect(() =>
+				registry.build("test", { enabled: "not-a-boolean" as unknown as boolean }),
+			).toThrow("Extension config validation failed");
+		});
+
+		it("delegates to validateExtensionConfig from core", () => {
+			const registry = new ExtensionRegistry();
+			registry.register("test", testTemplate);
+			const config = { label: "delegated" };
+			// Build via registry
+			const registryResult = registry.build("test", config);
+			// Build via core directly
+			const coreResult = validateExtensionConfig(testTemplate, config);
+			// Both should produce functions
+			expect(typeof registryResult).toBe("function");
+			expect(typeof coreResult).toBe("function");
+		});
+	});
+});

--- a/packages/extension-registry/src/registry.ts
+++ b/packages/extension-registry/src/registry.ts
@@ -1,0 +1,105 @@
+/**
+ * ExtensionRegistry — a dynamic registry of named extension templates.
+ *
+ * Provides methods to register, look up, and build extensions by name.
+ * A default pre-populated singleton is available via {@link defaultRegistry}.
+ */
+import { validateExtensionConfig } from "@otter-agent/core";
+import type { ExtensionTemplate } from "@otter-agent/core";
+import type { Extension } from "@otter-agent/core";
+
+/**
+ * Error thrown when attempting to register a template under a name
+ * that is already in use.
+ */
+export class ExtensionRegistryError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ExtensionRegistryError";
+	}
+}
+
+/**
+ * A dynamic registry of named extension templates.
+ *
+ * Templates are registered with a unique string name and can be built
+ * into concrete Extension functions with validated config.
+ *
+ * @example
+ * ```ts
+ * const registry = new ExtensionRegistry();
+ * registry.register("my-ext", myTemplate);
+ *
+ * const extension = registry.build("my-ext", { someOption: true });
+ * ```
+ */
+export class ExtensionRegistry {
+	private readonly _templates = new Map<string, ExtensionTemplate>();
+
+	/**
+	 * Register a template under the given name.
+	 *
+	 * @param name - Unique name for the template. Must not already be registered.
+	 * @param template - The extension template to register.
+	 * @throws {ExtensionRegistryError} If a template with the same name is already registered.
+	 */
+	register(name: string, template: ExtensionTemplate): void {
+		if (this._templates.has(name)) {
+			throw new ExtensionRegistryError(`Extension template "${name}" is already registered.`);
+		}
+		this._templates.set(name, template);
+	}
+
+	/**
+	 * Get a registered template by name.
+	 *
+	 * @param name - The registered template name.
+	 * @returns The template, or `undefined` if not found.
+	 */
+	get(name: string): ExtensionTemplate | undefined {
+		return this._templates.get(name);
+	}
+
+	/**
+	 * Check if a template is registered under the given name.
+	 *
+	 * @param name - The template name to check.
+	 * @returns `true` if a template is registered with this name.
+	 */
+	has(name: string): boolean {
+		return this._templates.has(name);
+	}
+
+	/**
+	 * List all registered template names.
+	 *
+	 * @returns Array of registered names in insertion order.
+	 */
+	getRegisteredNames(): string[] {
+		return [...this._templates.keys()];
+	}
+
+	/**
+	 * Build an extension by name with optional config.
+	 *
+	 * Delegates to {@link validateExtensionConfig} from `@otter-agent/core`
+	 * for schema validation, default merging, and extension building.
+	 *
+	 * @param name - The registered template name.
+	 * @param config - Optional user-provided config. Deep-merged with the
+	 *   template's defaults before validation.
+	 * @returns A built Extension ready for use with AgentSession.
+	 * @throws {ExtensionRegistryError} If no template is registered under the given name.
+	 * @throws {ExtensionConfigValidationError} If config validation fails.
+	 */
+	build(name: string, config?: Record<string, unknown>): Extension {
+		const template = this._templates.get(name);
+		if (!template) {
+			throw new ExtensionRegistryError(
+				`No extension template registered under "${name}". ` +
+					`Registered: ${this.getRegisteredNames().join(", ") || "(none)"}`,
+			);
+		}
+		return validateExtensionConfig(template, config);
+	}
+}

--- a/packages/extension-registry/tsconfig.json
+++ b/packages/extension-registry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Add a new `@otter-agent/extension-registry` package that provides a dynamic registry of named extension templates, a default pre-populated singleton, and convenience functions for building extensions by name.

Closes #83

## What's included

- **`ExtensionRegistry` class** — `register`, `get`, `has`, `getRegisteredNames`, `build`
  - `register()` throws on duplicate names
  - `build()` delegates to `validateExtensionConfig()` from `@otter-agent/core`
  - `build()` throws with descriptive error listing registered names for unknown lookups
- **Default registry singleton** — pre-populated with all built-in templates
- **Context Injector template** — first built-in, appends custom text to system prompt each turn (canonical example of the pattern)
- **Convenience functions** — `buildExtension()`, `isRegistered()`, `getRegisteredNames()`
- **Individual exports** — all built-in templates importable directly

## Tests

40 tests across 4 test files, all passing. 568 total across the monorepo.

## Verification

- [x] All packages build cleanly
- [x] All tests pass
- [x] Lint clean (no new issues)
- [x] Code review approved (two rounds)