### PR TITLE
feat: configurable component templates for CLI-launched RPC agents

### DIFF
--- a/packages/otter-agent-cli/src/args.test.ts
+++ b/packages/otter-agent-cli/src/args.test.ts
@@ -2,7 +2,18 @@ import { describe, expect, test } from "bun:test";
 import { parseCliArgs } from "./args.js";
 
 describe("parseCliArgs", () => {
-	const baseArgs = ["--provider", "anthropic", "--model", "claude-sonnet-4-5-20250514"];
+	const baseArgs = [
+		"--provider",
+		"anthropic",
+		"--model",
+		"claude-sonnet-4-5-20250514",
+		"--session-manager-config",
+		"./sm.yaml",
+		"--auth-storage-config",
+		"./auth.yaml",
+		"--agent-environment-config",
+		"./env.yaml",
+	];
 
 	test("defaults to rpc mode", () => {
 		const args = parseCliArgs(baseArgs);
@@ -17,9 +28,22 @@ describe("parseCliArgs", () => {
 
 	test("exits when --provider is missing", async () => {
 		const cliPath = new URL("../dist/cli.js", import.meta.url).pathname;
-		const proc = Bun.spawn(["bun", "run", cliPath, "--model", "claude-sonnet-4-5-20250514"], {
-			stderr: "pipe",
-		});
+		const proc = Bun.spawn(
+			[
+				"bun",
+				"run",
+				cliPath,
+				"--model",
+				"claude-sonnet-4-5-20250514",
+				"--session-manager-config",
+				"./sm.yaml",
+				"--auth-storage-config",
+				"./auth.yaml",
+				"--agent-environment-config",
+				"./env.yaml",
+			],
+			{ stderr: "pipe" },
+		);
 		await proc.exited;
 		expect(proc.exitCode).toBe(1);
 		const stderr = await new Response(proc.stderr).text();
@@ -28,17 +52,119 @@ describe("parseCliArgs", () => {
 
 	test("exits when --model is missing", async () => {
 		const cliPath = new URL("../dist/cli.js", import.meta.url).pathname;
-		const proc = Bun.spawn(["bun", "run", cliPath, "--provider", "anthropic"], {
-			stderr: "pipe",
-		});
+		const proc = Bun.spawn(
+			[
+				"bun",
+				"run",
+				cliPath,
+				"--provider",
+				"anthropic",
+				"--session-manager-config",
+				"./sm.yaml",
+				"--auth-storage-config",
+				"./auth.yaml",
+				"--agent-environment-config",
+				"./env.yaml",
+			],
+			{ stderr: "pipe" },
+		);
 		await proc.exited;
 		expect(proc.exitCode).toBe(1);
 		const stderr = await new Response(proc.stderr).text();
 		expect(stderr).toContain("--model is required");
 	});
 
-	test("parses --api-key", () => {
-		const args = parseCliArgs([...baseArgs, "--api-key", "sk-test-key"]);
+	test("exits when --session-manager-config is missing", async () => {
+		const cliPath = new URL("../dist/cli.js", import.meta.url).pathname;
+		const proc = Bun.spawn(
+			[
+				"bun",
+				"run",
+				cliPath,
+				"--provider",
+				"anthropic",
+				"--model",
+				"claude-sonnet-4-5-20250514",
+				"--auth-storage-config",
+				"./auth.yaml",
+				"--agent-environment-config",
+				"./env.yaml",
+			],
+			{ stderr: "pipe" },
+		);
+		await proc.exited;
+		expect(proc.exitCode).toBe(1);
+		const stderr = await new Response(proc.stderr).text();
+		expect(stderr).toContain("--session-manager-config is required");
+	});
+
+	test("exits when --agent-environment-config is missing", async () => {
+		const cliPath = new URL("../dist/cli.js", import.meta.url).pathname;
+		const proc = Bun.spawn(
+			[
+				"bun",
+				"run",
+				cliPath,
+				"--provider",
+				"anthropic",
+				"--model",
+				"claude-sonnet-4-5-20250514",
+				"--session-manager-config",
+				"./sm.yaml",
+				"--auth-storage-config",
+				"./auth.yaml",
+			],
+			{ stderr: "pipe" },
+		);
+		await proc.exited;
+		expect(proc.exitCode).toBe(1);
+		const stderr = await new Response(proc.stderr).text();
+		expect(stderr).toContain("--agent-environment-config is required");
+	});
+
+	test("exits when --api-key and --auth-storage-config are both provided", async () => {
+		const cliPath = new URL("../dist/cli.js", import.meta.url).pathname;
+		const proc = Bun.spawn(
+			[
+				"bun",
+				"run",
+				cliPath,
+				"--provider",
+				"anthropic",
+				"--model",
+				"claude-sonnet-4-5-20250514",
+				"--api-key",
+				"sk-test",
+				"--session-manager-config",
+				"./sm.yaml",
+				"--auth-storage-config",
+				"./auth.yaml",
+				"--agent-environment-config",
+				"./env.yaml",
+			],
+			{ stderr: "pipe" },
+		);
+		await proc.exited;
+		expect(proc.exitCode).toBe(1);
+		const stderr = await new Response(proc.stderr).text();
+		expect(stderr).toContain("mutually exclusive");
+	});
+
+	test("parses --api-key (without --auth-storage-config)", () => {
+		// baseArgs includes --auth-storage-config, so use args without it
+		const argsWithoutAuthConfig = [
+			"--provider",
+			"anthropic",
+			"--model",
+			"claude-sonnet-4-5-20250514",
+			"--session-manager-config",
+			"./sm.yaml",
+			"--agent-environment-config",
+			"./env.yaml",
+			"--api-key",
+			"sk-test-key",
+		];
+		const args = parseCliArgs(argsWithoutAuthConfig);
 		expect(args.apiKey).toBe("sk-test-key");
 	});
 
@@ -60,9 +186,32 @@ describe("parseCliArgs", () => {
 		expect(args.systemPrompt).toBe("You are a helpful assistant.");
 	});
 
-	test("parses --cwd", () => {
+	test("parses all three component config flags", () => {
+		const args = parseCliArgs(baseArgs);
+		expect(args.sessionManagerConfig).toBe("./sm.yaml");
+		expect(args.authStorageConfig).toBe("./auth.yaml");
+		expect(args.agentEnvironmentConfig).toBe("./env.yaml");
+	});
+
+	test("authStorageConfig is undefined when --auth-storage-config is not provided", () => {
+		const argsWithoutAuth = [
+			"--provider",
+			"anthropic",
+			"--model",
+			"claude-sonnet-4-5-20250514",
+			"--session-manager-config",
+			"./sm.yaml",
+			"--agent-environment-config",
+			"./env.yaml",
+		];
+		const args = parseCliArgs(argsWithoutAuth);
+		expect(args.authStorageConfig).toBeUndefined();
+	});
+
+	test("--cwd flag is not recognised (no cwd field)", () => {
+		// --cwd has been removed; passing it is silently ignored (strict: false)
 		const args = parseCliArgs([...baseArgs, "--cwd", "/workspace"]);
-		expect(args.cwd).toBe("/workspace");
+		expect(args).not.toHaveProperty("cwd");
 	});
 
 	test("sets help flag", () => {
@@ -79,7 +228,6 @@ describe("parseCliArgs", () => {
 		const args = parseCliArgs(baseArgs);
 		expect(args.thinking).toBeUndefined();
 		expect(args.systemPrompt).toBeUndefined();
-		expect(args.cwd).toBeUndefined();
 		expect(args.apiKey).toBeUndefined();
 	});
 

--- a/packages/otter-agent-cli/src/args.ts
+++ b/packages/otter-agent-cli/src/args.ts
@@ -10,7 +10,10 @@ export interface ParsedArgs {
 	apiKey: string | undefined;
 	thinking: ThinkingLevel | undefined;
 	systemPrompt: string | undefined;
-	cwd: string | undefined;
+	sessionManagerConfig: string;
+	/** Provided via --auth-storage-config. When absent, env vars / --api-key are used. */
+	authStorageConfig: string | undefined;
+	agentEnvironmentConfig: string;
 	extensions: string[];
 	help: boolean;
 	version: boolean;
@@ -20,16 +23,18 @@ const HELP = `
 Usage: otter [options]
 
 Options:
-  --mode <mode>           Operation mode. Currently only "rpc" is supported.
-  --provider <name>       LLM provider (e.g. anthropic, openai, google). Required.
-  --model <id>            Model ID (e.g. claude-sonnet-4-5-20250514). Required.
-  --api-key <key>         API key for the provider. Overrides the environment variable.
-  --thinking <level>      Thinking level: off, minimal, low, medium, high, xhigh.
-  --system-prompt <text>  Base system prompt.
-  --cwd <path>            Working directory for the agent environment.
-  --extension, -e <path>  Load an extension config file (JSON or YAML). Can be repeated.
-  --help                  Show this help message.
-  --version               Print the version and exit.
+  --mode <mode>                    Operation mode. Currently only "rpc" is supported.
+  --provider <name>                LLM provider (e.g. anthropic, openai, google). Required.
+  --model <id>                     Model ID (e.g. claude-sonnet-4-5-20250514). Required.
+  --api-key <key>                  API key for the provider. Mutually exclusive with --auth-storage-config.
+  --thinking <level>               Thinking level: off, minimal, low, medium, high, xhigh.
+  --system-prompt <text>           Base system prompt.
+  --session-manager-config <path>  Session manager config file (JSON or YAML). Required.
+  --auth-storage-config <path>     Auth storage config file (JSON or YAML). Mutually exclusive with --api-key.
+  --agent-environment-config <path> Agent environment config file (JSON or YAML). Required.
+  --extension, -e <path>           Load an extension config file (JSON or YAML). Can be repeated.
+  --help                           Show this help message.
+  --version                        Print the version and exit.
 `.trim();
 
 /**
@@ -71,7 +76,9 @@ export function parseCliArgs(argv: string[]): ParsedArgs {
 			"api-key": { type: "string" },
 			thinking: { type: "string" },
 			"system-prompt": { type: "string" },
-			cwd: { type: "string" },
+			"session-manager-config": { type: "string" },
+			"auth-storage-config": { type: "string" },
+			"agent-environment-config": { type: "string" },
 			help: { type: "boolean", default: false },
 			version: { type: "boolean", default: false },
 		},
@@ -97,7 +104,7 @@ export function parseCliArgs(argv: string[]): ParsedArgs {
 	const help = (values.help as boolean | undefined) ?? false;
 	const version = (values.version as boolean | undefined) ?? false;
 
-	// --help and --version short-circuit without requiring --provider/--model.
+	// --help and --version short-circuit without requiring other flags.
 	if (help || version) {
 		return {
 			mode: "rpc",
@@ -106,7 +113,9 @@ export function parseCliArgs(argv: string[]): ParsedArgs {
 			apiKey: undefined,
 			thinking,
 			systemPrompt: values["system-prompt"] as string | undefined,
-			cwd: values.cwd as string | undefined,
+			sessionManagerConfig: "",
+			authStorageConfig: undefined,
+			agentEnvironmentConfig: "",
 			extensions,
 			help,
 			version,
@@ -115,6 +124,10 @@ export function parseCliArgs(argv: string[]): ParsedArgs {
 
 	const provider = values.provider as string | undefined;
 	const model = values.model as string | undefined;
+	const apiKey = values["api-key"] as string | undefined;
+	const authStorageConfig = values["auth-storage-config"] as string | undefined;
+	const sessionManagerConfig = values["session-manager-config"] as string | undefined;
+	const agentEnvironmentConfig = values["agent-environment-config"] as string | undefined;
 
 	if (!provider) {
 		console.error("Error: --provider is required.");
@@ -130,14 +143,38 @@ export function parseCliArgs(argv: string[]): ParsedArgs {
 		process.exit(1);
 	}
 
+	if (apiKey !== undefined && authStorageConfig !== undefined) {
+		console.error("Error: --api-key and --auth-storage-config are mutually exclusive.");
+		console.error(
+			"Use --api-key to pass a key directly, or --auth-storage-config to load from a config file.",
+		);
+		process.exit(1);
+	}
+
+	if (!sessionManagerConfig) {
+		console.error("Error: --session-manager-config is required.");
+		console.error("Use --session-manager-config <path> to specify a session manager config file.");
+		process.exit(1);
+	}
+
+	if (!agentEnvironmentConfig) {
+		console.error("Error: --agent-environment-config is required.");
+		console.error(
+			"Use --agent-environment-config <path> to specify an agent environment config file.",
+		);
+		process.exit(1);
+	}
+
 	return {
 		mode: "rpc",
 		provider,
 		model,
-		apiKey: values["api-key"] as string | undefined,
+		apiKey,
 		thinking,
 		systemPrompt: values["system-prompt"] as string | undefined,
-		cwd: values.cwd as string | undefined,
+		sessionManagerConfig,
+		authStorageConfig,
+		agentEnvironmentConfig,
 		extensions,
 		help: false,
 		version: false,

--- a/packages/otter-agent-cli/src/fixtures/valid-session-manager.json
+++ b/packages/otter-agent-cli/src/fixtures/valid-session-manager.json
@@ -1,0 +1,6 @@
+{
+  "path": "./valid-session-manager.ts",
+  "config": {
+    "label": "test-session"
+  }
+}

--- a/packages/otter-agent-cli/src/fixtures/valid-session-manager.ts
+++ b/packages/otter-agent-cli/src/fixtures/valid-session-manager.ts
@@ -1,0 +1,20 @@
+import { InMemorySessionManager } from "@otter-agent/core";
+import type { ComponentTemplate } from "@otter-agent/core";
+import { Type } from "@sinclair/typebox";
+
+/**
+ * Minimal valid ComponentTemplate for testing.
+ *
+ * Produces an InMemorySessionManager so no filesystem side-effects occur.
+ * Config schema: { label?: string }
+ */
+const template: ComponentTemplate = {
+	configSchema: () =>
+		Type.Object({
+			label: Type.Optional(Type.String()),
+		}),
+	defaultConfig: () => ({ label: "test" }),
+	build: () => new InMemorySessionManager(),
+};
+
+export default template;

--- a/packages/otter-agent-cli/src/load-component.test.ts
+++ b/packages/otter-agent-cli/src/load-component.test.ts
@@ -79,6 +79,16 @@ describe("resolveTemplatePath", () => {
 		const resolved = resolveTemplatePath("my-package/index.js", "/some/dir");
 		expect(resolved).toBe("my-package/index.js");
 	});
+
+	test("resolves parent-relative paths against configDir", () => {
+		const resolved = resolveTemplatePath("../sibling/foo.ts", "/some/dir");
+		expect(resolved).toBe("/some/sibling/foo.ts");
+	});
+
+	test("resolves deeply nested relative paths", () => {
+		const resolved = resolveTemplatePath("./sub/dir/template.ts", "/base/config");
+		expect(resolved).toBe("/base/config/sub/dir/template.ts");
+	});
 });
 
 describe("loadComponentTemplate", () => {

--- a/packages/otter-agent-cli/src/load-component.test.ts
+++ b/packages/otter-agent-cli/src/load-component.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ComponentConfigValidationError } from "@otter-agent/core";
+import {
+	ComponentConfigFileError,
+	ComponentLoadError,
+	loadComponent,
+	loadComponentTemplate,
+	parseComponentConfigFile,
+	resolveTemplatePath,
+} from "./load-component.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "fixtures");
+
+const validSmJson = resolve(fixturesDir, "valid-session-manager.json");
+const badJsonConfig = resolve(fixturesDir, "bad-config.json");
+const missingPathConfig = resolve(fixturesDir, "missing-path.json");
+const nonExistentFile = resolve(fixturesDir, "does-not-exist.json");
+const noExportRefConfig = resolve(fixturesDir, "no-export-ref.json");
+const nonExistentPathConfig = resolve(fixturesDir, "non-existent-path.json");
+const unsupportedExt = resolve(fixturesDir, "unsupported.txt");
+
+describe("parseComponentConfigFile", () => {
+	test("parses a valid JSON config file", () => {
+		const entry = parseComponentConfigFile(validSmJson);
+		expect(entry.path).toBe("./valid-session-manager.ts");
+		expect(entry.config).toEqual({ label: "test-session" });
+	});
+
+	test("throws ComponentConfigFileError for non-existent file", () => {
+		expect(() => parseComponentConfigFile(nonExistentFile)).toThrow(ComponentConfigFileError);
+	});
+
+	test("throws ComponentConfigFileError for invalid JSON", () => {
+		expect(() => parseComponentConfigFile(badJsonConfig)).toThrow(ComponentConfigFileError);
+	});
+
+	test("throws ComponentConfigFileError for missing path", () => {
+		expect(() => parseComponentConfigFile(missingPathConfig)).toThrow(ComponentConfigFileError);
+	});
+
+	test("throws ComponentConfigFileError for unsupported extension", () => {
+		expect(() => parseComponentConfigFile(unsupportedExt)).toThrow(ComponentConfigFileError);
+	});
+
+	test("ComponentConfigFileError includes filePath", () => {
+		try {
+			parseComponentConfigFile(nonExistentFile);
+			expect.unreachable("Should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ComponentConfigFileError);
+			expect((err as ComponentConfigFileError).filePath).toBe(nonExistentFile);
+		}
+	});
+});
+
+describe("resolveTemplatePath", () => {
+	test("resolves relative paths against configDir", () => {
+		const resolved = resolveTemplatePath("./foo.ts", "/some/dir");
+		expect(resolved).toBe("/some/dir/foo.ts");
+	});
+
+	test("returns absolute paths unchanged", () => {
+		const resolved = resolveTemplatePath("/abs/path/foo.ts", "/some/dir");
+		expect(resolved).toBe("/abs/path/foo.ts");
+	});
+
+	test("returns package specifiers unchanged", () => {
+		const resolved = resolveTemplatePath(
+			"@otter-agent/core/dist/session-managers/sqlite-session-manager.js",
+			"/some/dir",
+		);
+		expect(resolved).toBe("@otter-agent/core/dist/session-managers/sqlite-session-manager.js");
+	});
+
+	test("returns bare package names unchanged", () => {
+		const resolved = resolveTemplatePath("my-package/index.js", "/some/dir");
+		expect(resolved).toBe("my-package/index.js");
+	});
+});
+
+describe("loadComponentTemplate", () => {
+	test("loads a valid ComponentTemplate from a .ts file", async () => {
+		const template = await loadComponentTemplate("./valid-session-manager.ts", fixturesDir);
+		expect(typeof template.configSchema).toBe("function");
+		expect(typeof template.defaultConfig).toBe("function");
+		expect(typeof template.build).toBe("function");
+	});
+
+	test("resolves absolute path", async () => {
+		const absPath = resolve(fixturesDir, "valid-session-manager.ts");
+		const template = await loadComponentTemplate(absPath, fixturesDir);
+		expect(typeof template.build).toBe("function");
+	});
+
+	test("throws ComponentLoadError when module has no default export", async () => {
+		await expect(loadComponentTemplate("./no-export.ts", fixturesDir)).rejects.toThrow(
+			ComponentLoadError,
+		);
+	});
+
+	test("throws ComponentLoadError when file does not exist", async () => {
+		await expect(loadComponentTemplate("./non-existent-template.ts", fixturesDir)).rejects.toThrow(
+			ComponentLoadError,
+		);
+	});
+
+	test("ComponentLoadError message mentions no default export", async () => {
+		try {
+			await loadComponentTemplate("./no-export.ts", fixturesDir);
+			expect.unreachable("Should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ComponentLoadError);
+			expect((err as ComponentLoadError).message).toContain("no default export");
+		}
+	});
+});
+
+describe("loadComponent", () => {
+	test("loads and builds a component from a JSON config", async () => {
+		const instance = await loadComponent(validSmJson);
+		expect(instance).toBeDefined();
+		// The fixture builds an InMemorySessionManager — check a known method
+		expect(typeof (instance as { getEntries?: unknown }).getEntries).toBe("function");
+	});
+
+	test("throws ComponentConfigFileError for bad config file", async () => {
+		await expect(loadComponent(badJsonConfig)).rejects.toThrow(ComponentConfigFileError);
+	});
+
+	test("throws ComponentLoadError for missing template", async () => {
+		await expect(loadComponent(nonExistentPathConfig)).rejects.toThrow(ComponentLoadError);
+	});
+
+	test("throws ComponentLoadError for no-export template reference", async () => {
+		await expect(loadComponent(noExportRefConfig)).rejects.toThrow(ComponentLoadError);
+	});
+});

--- a/packages/otter-agent-cli/src/load-component.ts
+++ b/packages/otter-agent-cli/src/load-component.ts
@@ -1,0 +1,211 @@
+import { readFileSync } from "node:fs";
+import { dirname, extname, isAbsolute, resolve } from "node:path";
+import type { ComponentTemplate } from "@otter-agent/core";
+import { ComponentConfigValidationError, validateComponentConfig } from "@otter-agent/core";
+import type { TSchema } from "@sinclair/typebox";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * Parsed component config entry.
+ */
+export interface ComponentConfigEntry {
+	/** Path to the module exporting a ComponentTemplate as its default export. */
+	path: string;
+	/** User-provided config to validate and pass to the template builder. */
+	config: Record<string, unknown>;
+}
+
+/**
+ * Error thrown when a component config file cannot be parsed or is invalid.
+ */
+export class ComponentConfigFileError extends Error {
+	constructor(
+		public readonly filePath: string,
+		message: string,
+	) {
+		super(`Component config file "${filePath}": ${message}`);
+		this.name = "ComponentConfigFileError";
+	}
+}
+
+/**
+ * Error thrown when a component template cannot be loaded.
+ */
+export class ComponentLoadError extends Error {
+	constructor(
+		public readonly templatePath: string,
+		message: string,
+	) {
+		super(`Failed to load component template "${templatePath}": ${message}`);
+		this.name = "ComponentLoadError";
+	}
+}
+
+/**
+ * Parse a component config file (JSON or YAML).
+ *
+ * The file must contain a JSON object or YAML mapping with at least a
+ * `path` property (string) pointing to the component template module.
+ * An optional `config` property provides configuration to validate
+ * against the template's schema.
+ *
+ * This function is also used internally by {@link load-extensions.ts} for
+ * extension config parsing.
+ *
+ * @param filePath - Absolute or relative path to the config file.
+ * @returns The parsed config entry.
+ * @throws {ComponentConfigFileError} If the file cannot be read, parsed,
+ *   or is missing the required `path` property.
+ */
+export function parseComponentConfigFile(filePath: string): ComponentConfigEntry {
+	let content: string;
+	try {
+		content = readFileSync(filePath, "utf-8");
+	} catch (err) {
+		throw new ComponentConfigFileError(filePath, err instanceof Error ? err.message : String(err));
+	}
+
+	const ext = extname(filePath).toLowerCase();
+	let parsed: unknown;
+
+	if (ext === ".json") {
+		try {
+			parsed = JSON.parse(content);
+		} catch (err) {
+			throw new ComponentConfigFileError(
+				filePath,
+				`Invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	} else if (ext === ".yaml" || ext === ".yml") {
+		try {
+			parsed = parseYaml(content);
+		} catch (err) {
+			throw new ComponentConfigFileError(
+				filePath,
+				`Invalid YAML: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	} else {
+		throw new ComponentConfigFileError(
+			filePath,
+			`Unsupported file extension "${ext}". Expected .json, .yaml, or .yml.`,
+		);
+	}
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new ComponentConfigFileError(
+			filePath,
+			"Config file must contain a JSON object or YAML mapping.",
+		);
+	}
+
+	const record = parsed as Record<string, unknown>;
+
+	if (typeof record.path !== "string" || record.path.length === 0) {
+		throw new ComponentConfigFileError(
+			filePath,
+			'Missing or invalid "path" property. It must be a non-empty string pointing to a template module.',
+		);
+	}
+
+	return {
+		path: record.path,
+		config:
+			typeof record.config === "object" && record.config !== null && !Array.isArray(record.config)
+				? (record.config as Record<string, unknown>)
+				: {},
+	};
+}
+
+/**
+ * Resolve a template path for use with `import()`.
+ *
+ * Uses a path-prefix heuristic:
+ * - Starts with `.` or `..` → relative file path, resolved against `configDir`
+ * - Starts with `/` → absolute path, used as-is
+ * - Anything else → package specifier, passed directly to `import()`
+ *   (e.g. `@otter-agent/core/dist/...` resolves through node_modules)
+ *
+ * @param templatePath - The `path` value from the config file.
+ * @param configDir - Directory of the config file; used to resolve relative paths.
+ * @returns The path or specifier to pass to `import()`.
+ */
+export function resolveTemplatePath(templatePath: string, configDir: string): string {
+	if (templatePath.startsWith(".") || templatePath.startsWith("/")) {
+		return isAbsolute(templatePath) ? templatePath : resolve(configDir, templatePath);
+	}
+	// Package specifier — return as-is for Node/Bun module resolution
+	return templatePath;
+}
+
+/**
+ * Load a {@link ComponentTemplate} from a TypeScript or JavaScript module.
+ *
+ * The module must have a default export that is a `ComponentTemplate`.
+ *
+ * @param templatePath - Path or package specifier for the template module.
+ * @param configDir - Directory of the config file; used to resolve relative paths.
+ * @returns The loaded ComponentTemplate.
+ * @throws {ComponentLoadError} If the module cannot be imported, has no
+ *   default export, or the default export is not a ComponentTemplate.
+ */
+export async function loadComponentTemplate<TInstance>(
+	templatePath: string,
+	configDir: string,
+): Promise<ComponentTemplate<TSchema, TInstance>> {
+	const resolved = resolveTemplatePath(templatePath, configDir);
+
+	let mod: Record<string, unknown>;
+	try {
+		mod = await import(resolved);
+	} catch (err) {
+		throw new ComponentLoadError(
+			resolved,
+			`Import failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+
+	if (mod.default === undefined) {
+		throw new ComponentLoadError(
+			resolved,
+			"Module has no default export. Component templates must use `export default`.",
+		);
+	}
+
+	const template = mod.default as ComponentTemplate<TSchema, TInstance>;
+
+	if (
+		typeof template.configSchema !== "function" ||
+		typeof template.defaultConfig !== "function" ||
+		typeof template.build !== "function"
+	) {
+		throw new ComponentLoadError(
+			resolved,
+			"Default export does not implement the ComponentTemplate interface. Expected configSchema(), defaultConfig(), and build() methods.",
+		);
+	}
+
+	return template;
+}
+
+/**
+ * Load and build a component from a config file path.
+ *
+ * This is the full pipeline: parse config file → load template → validate
+ * config → build instance. Any error at any stage throws (fatal).
+ *
+ * @param configPath - Path to the JSON or YAML config file.
+ * @returns The built component instance.
+ * @throws {ComponentConfigFileError} If the config file is invalid.
+ * @throws {ComponentLoadError} If the template module cannot be loaded.
+ * @throws {ComponentConfigValidationError} If config validation fails.
+ */
+export async function loadComponent<TInstance>(configPath: string): Promise<TInstance> {
+	const entry = parseComponentConfigFile(configPath);
+	const configDir = dirname(configPath);
+	const template = await loadComponentTemplate<TInstance>(entry.path, configDir);
+	return validateComponentConfig(template, entry.config);
+}
+
+export { ComponentConfigValidationError };

--- a/packages/otter-agent-cli/src/load-extensions.test.ts
+++ b/packages/otter-agent-cli/src/load-extensions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionTemplate } from "@otter-agent/core";
@@ -169,16 +169,6 @@ describe("loadExtensionTemplate", () => {
 });
 
 describe("loadExtensionsFromConfigFiles", () => {
-	let warnSpy: ReturnType<typeof spyOn>;
-
-	beforeEach(() => {
-		warnSpy = spyOn(console, "warn").mockImplementation(() => {});
-	});
-
-	afterEach(() => {
-		warnSpy.mockRestore();
-	});
-
 	test("successfully loads a single extension", async () => {
 		const extensions = await loadExtensionsFromConfigFiles([validJsonConfig]);
 		expect(extensions.length).toBe(1);
@@ -208,57 +198,35 @@ describe("loadExtensionsFromConfigFiles", () => {
 	test("returns empty array when no config paths provided", async () => {
 		const extensions = await loadExtensionsFromConfigFiles([]);
 		expect(extensions).toEqual([]);
-		expect(warnSpy).not.toHaveBeenCalled();
 	});
 
-	test("skips a bad config file and logs a warning, returns the rest", async () => {
-		const extensions = await loadExtensionsFromConfigFiles([badJsonConfig, validJsonConfig]);
-		expect(extensions.length).toBe(1);
-		expect(typeof extensions[0]).toBe("function");
-		expect(warnSpy).toHaveBeenCalledTimes(1);
-		expect(warnSpy.mock.calls[0][0]).toContain("bad-config.json");
+	test("throws on a bad config file", async () => {
+		await expect(loadExtensionsFromConfigFiles([badJsonConfig])).rejects.toThrow(
+			ExtensionConfigFileError,
+		);
 	});
 
-	test("skips a bad template file (no default export) and logs a warning", async () => {
-		const extensions = await loadExtensionsFromConfigFiles([noExportRefConfig]);
-		expect(extensions.length).toBe(0);
-		expect(warnSpy).toHaveBeenCalledTimes(1);
-		expect(warnSpy.mock.calls[0][0]).toContain("no-export-ref.json");
+	test("throws on a template with no default export", async () => {
+		await expect(loadExtensionsFromConfigFiles([noExportRefConfig])).rejects.toThrow(
+			ExtensionLoadError,
+		);
 	});
 
-	test("skips a non-existent template path and logs a warning", async () => {
-		const extensions = await loadExtensionsFromConfigFiles([nonExistentPathConfig]);
-		expect(extensions.length).toBe(0);
-		expect(warnSpy).toHaveBeenCalledTimes(1);
-		expect(warnSpy.mock.calls[0][0]).toContain("non-existent-path.json");
+	test("throws on a non-existent template path", async () => {
+		await expect(loadExtensionsFromConfigFiles([nonExistentPathConfig])).rejects.toThrow(
+			ExtensionLoadError,
+		);
 	});
 
-	test("skips a validation failure and logs a warning with validation errors", async () => {
-		const extensions = await loadExtensionsFromConfigFiles([invalidConfigJson]);
-		expect(extensions.length).toBe(0);
-		expect(warnSpy).toHaveBeenCalledTimes(1);
-		const warningMsg = warnSpy.mock.calls[0][0] as string;
-		expect(warningMsg).toContain("config validation failed");
+	test("throws on a config validation failure", async () => {
+		await expect(loadExtensionsFromConfigFiles([invalidConfigJson])).rejects.toThrow(
+			ExtensionConfigValidationError,
+		);
 	});
 
-	test("returns empty array when all extensions fail", async () => {
-		const extensions = await loadExtensionsFromConfigFiles([
-			badJsonConfig,
-			noExportRefConfig,
-			invalidConfigJson,
-		]);
-		expect(extensions.length).toBe(0);
-		expect(warnSpy).toHaveBeenCalledTimes(3);
-	});
-
-	test("loads valid extensions and skips invalid ones in a mixed batch", async () => {
-		const extensions = await loadExtensionsFromConfigFiles([
-			validJsonConfig,
-			badJsonConfig,
-			validYamlConfig,
-			nonExistentPathConfig,
-		]);
-		expect(extensions.length).toBe(2);
-		expect(warnSpy).toHaveBeenCalledTimes(2);
+	test("throws on the first bad extension even when valid ones are also listed", async () => {
+		await expect(loadExtensionsFromConfigFiles([badJsonConfig, validJsonConfig])).rejects.toThrow(
+			ExtensionConfigFileError,
+		);
 	});
 });

--- a/packages/otter-agent-cli/src/load-extensions.test.ts
+++ b/packages/otter-agent-cli/src/load-extensions.test.ts
@@ -200,33 +200,35 @@ describe("loadExtensionsFromConfigFiles", () => {
 		expect(extensions).toEqual([]);
 	});
 
-	test("throws on a bad config file", async () => {
-		await expect(loadExtensionsFromConfigFiles([badJsonConfig])).rejects.toThrow(
-			ExtensionConfigFileError,
-		);
+	test("skips a bad config file and returns empty array", async () => {
+		const extensions = await loadExtensionsFromConfigFiles([badJsonConfig]);
+		expect(extensions).toEqual([]);
 	});
 
-	test("throws on a template with no default export", async () => {
-		await expect(loadExtensionsFromConfigFiles([noExportRefConfig])).rejects.toThrow(
-			ExtensionLoadError,
-		);
+	test("skips a template with no default export and returns empty array", async () => {
+		const extensions = await loadExtensionsFromConfigFiles([noExportRefConfig]);
+		expect(extensions).toEqual([]);
 	});
 
-	test("throws on a non-existent template path", async () => {
-		await expect(loadExtensionsFromConfigFiles([nonExistentPathConfig])).rejects.toThrow(
-			ExtensionLoadError,
-		);
+	test("skips a non-existent template path and returns empty array", async () => {
+		const extensions = await loadExtensionsFromConfigFiles([nonExistentPathConfig]);
+		expect(extensions).toEqual([]);
 	});
 
-	test("throws on a config validation failure", async () => {
-		await expect(loadExtensionsFromConfigFiles([invalidConfigJson])).rejects.toThrow(
-			ExtensionConfigValidationError,
-		);
+	test("skips a config validation failure and returns empty array", async () => {
+		const extensions = await loadExtensionsFromConfigFiles([invalidConfigJson]);
+		expect(extensions).toEqual([]);
 	});
 
-	test("throws on the first bad extension even when valid ones are also listed", async () => {
-		await expect(loadExtensionsFromConfigFiles([badJsonConfig, validJsonConfig])).rejects.toThrow(
-			ExtensionConfigFileError,
-		);
+	test("skips bad extension and returns only valid ones", async () => {
+		const extensions = await loadExtensionsFromConfigFiles([badJsonConfig, validJsonConfig]);
+		expect(extensions.length).toBe(1);
+		expect(typeof extensions[0]).toBe("function");
+	});
+
+	test("skips extension with validation failure and returns valid ones", async () => {
+		const extensions = await loadExtensionsFromConfigFiles([invalidConfigJson, validJsonConfig]);
+		expect(extensions.length).toBe(1);
+		expect(typeof extensions[0]).toBe("function");
 	});
 });

--- a/packages/otter-agent-cli/src/load-extensions.ts
+++ b/packages/otter-agent-cli/src/load-extensions.ts
@@ -121,23 +121,36 @@ export async function loadExtensionTemplate(
  * 2. Load the ExtensionTemplate from the template file
  * 3. Validate the config against the template's schema and build the Extension
  *
- * Errors are **fatal**: any failure immediately throws and halts the process.
+ * Errors are **non-fatal**: a warning is logged to stderr and the extension
+ * is skipped. Successfully loaded extensions are returned.
  *
  * @param configPaths - Array of paths to extension config files.
- * @returns Array of built Extension functions.
- * @throws {ExtensionConfigFileError} If any config file is invalid.
- * @throws {ExtensionLoadError} If any template module cannot be loaded.
- * @throws {ExtensionConfigValidationError} If any config validation fails.
+ * @returns Array of successfully built Extension functions.
  */
 export async function loadExtensionsFromConfigFiles(configPaths: string[]): Promise<Extension[]> {
 	const extensions: Extension[] = [];
 
 	for (const configPath of configPaths) {
-		const configEntry = parseExtensionConfigFile(configPath);
-		const configDir = dirname(configPath);
-		const template = await loadExtensionTemplate(configEntry.path, configDir);
-		const extension = validateExtensionConfig(template, configEntry.config);
-		extensions.push(extension);
+		try {
+			const configEntry = parseExtensionConfigFile(configPath);
+			const configDir = dirname(configPath);
+			const template = await loadExtensionTemplate(configEntry.path, configDir);
+			const extension = validateExtensionConfig(template, configEntry.config);
+			extensions.push(extension);
+		} catch (err) {
+			const label =
+				err instanceof ExtensionConfigFileError
+					? `Config file "${configPath}"`
+					: err instanceof ExtensionLoadError
+						? `Extension "${configPath}"`
+						: `Extension "${configPath}"`;
+
+			if (err instanceof ExtensionConfigValidationError) {
+				console.warn(`Warning: ${label} — config validation failed:\n${err.errors.join("\n")}`);
+			} else {
+				console.warn(`Warning: ${label} — ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
 	}
 
 	return extensions;

--- a/packages/otter-agent-cli/src/load-extensions.ts
+++ b/packages/otter-agent-cli/src/load-extensions.ts
@@ -1,42 +1,39 @@
-import { readFileSync } from "node:fs";
-import { dirname, extname, isAbsolute, resolve } from "node:path";
+import { dirname } from "node:path";
 import type { ExtensionTemplate } from "@otter-agent/core";
 import { ExtensionConfigValidationError, validateExtensionConfig } from "@otter-agent/core";
 import type { Extension } from "@otter-agent/core";
-import { parse as parseYaml } from "yaml";
+import {
+	type ComponentConfigEntry,
+	ComponentConfigFileError,
+	ComponentLoadError,
+	parseComponentConfigFile,
+	resolveTemplatePath,
+} from "./load-component.js";
 
 /**
- * Parsed extension config entry.
+ * Parsed extension config entry. Re-exported for backward compatibility.
+ * @deprecated Use {@link ComponentConfigEntry} from `./load-component.js`.
  */
-export interface ExtensionConfigEntry {
-	/** Path to the TypeScript or JavaScript file exporting an ExtensionTemplate. */
-	path: string;
-	/** User-provided config to validate and pass to the template builder. */
-	config: Record<string, unknown>;
-}
+export type ExtensionConfigEntry = ComponentConfigEntry;
 
 /**
  * Error thrown when an extension config file cannot be parsed or is invalid.
+ * Thin wrapper around {@link ComponentConfigFileError} for backward compatibility.
  */
-export class ExtensionConfigFileError extends Error {
-	constructor(
-		public readonly filePath: string,
-		message: string,
-	) {
-		super(`Extension config file "${filePath}": ${message}`);
+export class ExtensionConfigFileError extends ComponentConfigFileError {
+	constructor(filePath: string, message: string) {
+		super(filePath, message);
 		this.name = "ExtensionConfigFileError";
 	}
 }
 
 /**
  * Error thrown when an extension template cannot be loaded.
+ * Thin wrapper around {@link ComponentLoadError} for backward compatibility.
  */
-export class ExtensionLoadError extends Error {
-	constructor(
-		public readonly templatePath: string,
-		message: string,
-	) {
-		super(`Failed to load extension template "${templatePath}": ${message}`);
+export class ExtensionLoadError extends ComponentLoadError {
+	constructor(templatePath: string, message: string) {
+		super(templatePath, message);
 		this.name = "ExtensionLoadError";
 	}
 }
@@ -44,10 +41,8 @@ export class ExtensionLoadError extends Error {
 /**
  * Parse an extension config file (JSON or YAML).
  *
- * The file must contain a JSON object or YAML mapping with at least a
- * `path` property (string) pointing to the extension template file.
- * An optional `config` property provides configuration to validate
- * against the template's schema.
+ * Delegates to {@link parseComponentConfigFile} and re-throws any
+ * {@link ComponentConfigFileError} as an {@link ExtensionConfigFileError}.
  *
  * @param filePath - Absolute or relative path to the config file.
  * @returns The parsed config entry.
@@ -55,112 +50,62 @@ export class ExtensionLoadError extends Error {
  *   or is missing the required `path` property.
  */
 export function parseExtensionConfigFile(filePath: string): ExtensionConfigEntry {
-	let content: string;
 	try {
-		content = readFileSync(filePath, "utf-8");
+		return parseComponentConfigFile(filePath);
 	} catch (err) {
-		throw new ExtensionConfigFileError(filePath, err instanceof Error ? err.message : String(err));
-	}
-
-	const ext = extname(filePath).toLowerCase();
-	let parsed: unknown;
-
-	if (ext === ".json") {
-		try {
-			parsed = JSON.parse(content);
-		} catch (err) {
-			throw new ExtensionConfigFileError(
-				filePath,
-				`Invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
-			);
+		if (err instanceof ComponentConfigFileError) {
+			// Re-throw as ExtensionConfigFileError to preserve the error name/class
+			const msg = err.message.replace(/^Component config file "[^"]+": /, "");
+			throw new ExtensionConfigFileError(err.filePath, msg);
 		}
-	} else if (ext === ".yaml" || ext === ".yml") {
-		try {
-			parsed = parseYaml(content);
-		} catch (err) {
-			throw new ExtensionConfigFileError(
-				filePath,
-				`Invalid YAML: ${err instanceof Error ? err.message : String(err)}`,
-			);
-		}
-	} else {
-		throw new ExtensionConfigFileError(
-			filePath,
-			`Unsupported file extension "${ext}". Expected .json, .yaml, or .yml.`,
-		);
+		throw err;
 	}
-
-	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-		throw new ExtensionConfigFileError(
-			filePath,
-			"Config file must contain a JSON object or YAML mapping.",
-		);
-	}
-
-	const record = parsed as Record<string, unknown>;
-
-	if (typeof record.path !== "string" || record.path.length === 0) {
-		throw new ExtensionConfigFileError(
-			filePath,
-			'Missing or invalid "path" property. It must be a non-empty string pointing to an extension template file.',
-		);
-	}
-
-	return {
-		path: record.path,
-		config:
-			typeof record.config === "object" && record.config !== null && !Array.isArray(record.config)
-				? (record.config as Record<string, unknown>)
-				: {},
-	};
 }
 
 /**
  * Load an ExtensionTemplate from a TypeScript or JavaScript file.
  *
- * The templatePath is resolved relative to configDir if it is not absolute.
- * The module must have a default export that is an ExtensionTemplate.
+ * Delegates to the shared path resolution and import logic, then validates
+ * the extension-specific interface shape (configSchema, defaultConfig, buildExtension).
  *
  * @param templatePath - Path to the extension template file (.ts or .js).
- * @param configDir - Directory to resolve relative paths against (typically
- *   the directory containing the config file).
+ * @param configDir - Directory to resolve relative paths against.
  * @returns The loaded ExtensionTemplate.
- * @throws {ExtensionLoadError} If the module cannot be imported or has no
- *   default export, or if the default export is not an ExtensionTemplate.
+ * @throws {ExtensionLoadError} If the module cannot be imported, has no
+ *   default export, or does not implement ExtensionTemplate.
  */
 export async function loadExtensionTemplate(
 	templatePath: string,
 	configDir: string,
 ): Promise<ExtensionTemplate> {
-	const resolvedPath = isAbsolute(templatePath) ? templatePath : resolve(configDir, templatePath);
+	const resolved = resolveTemplatePath(templatePath, configDir);
 
 	let mod: Record<string, unknown>;
 	try {
-		mod = await import(resolvedPath);
+		mod = await import(resolved);
 	} catch (err) {
 		throw new ExtensionLoadError(
-			resolvedPath,
+			resolved,
 			`Import failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
 	}
 
 	if (mod.default === undefined) {
 		throw new ExtensionLoadError(
-			resolvedPath,
+			resolved,
 			"Module has no default export. Extension templates must use `export default`.",
 		);
 	}
 
 	const template = mod.default as ExtensionTemplate;
 
-	// Basic shape check: ExtensionTemplate must have configSchema, defaultConfig, buildExtension
 	if (
 		typeof template.configSchema !== "function" ||
 		typeof template.defaultConfig !== "function" ||
 		typeof template.buildExtension !== "function"
 	) {
 		throw new ExtensionLoadError(
-			resolvedPath,
+			resolved,
 			"Default export does not implement the ExtensionTemplate interface. Expected configSchema(), defaultConfig(), and buildExtension() methods.",
 		);
 	}
@@ -176,37 +121,26 @@ export async function loadExtensionTemplate(
  * 2. Load the ExtensionTemplate from the template file
  * 3. Validate the config against the template's schema and build the Extension
  *
- * Errors are non-fatal: a warning is logged to stderr and the extension
- * is skipped. Successfully loaded extensions are returned.
+ * Errors are **fatal**: any failure immediately throws and halts the process.
  *
  * @param configPaths - Array of paths to extension config files.
- * @returns Array of successfully built Extension functions.
+ * @returns Array of built Extension functions.
+ * @throws {ExtensionConfigFileError} If any config file is invalid.
+ * @throws {ExtensionLoadError} If any template module cannot be loaded.
+ * @throws {ExtensionConfigValidationError} If any config validation fails.
  */
 export async function loadExtensionsFromConfigFiles(configPaths: string[]): Promise<Extension[]> {
 	const extensions: Extension[] = [];
 
 	for (const configPath of configPaths) {
-		try {
-			const configEntry = parseExtensionConfigFile(configPath);
-			const configDir = dirname(configPath);
-			const template = await loadExtensionTemplate(configEntry.path, configDir);
-			const extension = validateExtensionConfig(template, configEntry.config);
-			extensions.push(extension);
-		} catch (err) {
-			const label =
-				err instanceof ExtensionConfigFileError
-					? `Config file "${configPath}"`
-					: err instanceof ExtensionLoadError
-						? `Extension "${configPath}"`
-						: `Extension "${configPath}"`;
-
-			if (err instanceof ExtensionConfigValidationError) {
-				console.warn(`Warning: ${label} — config validation failed:\n${err.errors.join("\n")}`);
-			} else {
-				console.warn(`Warning: ${label} — ${err instanceof Error ? err.message : String(err)}`);
-			}
-		}
+		const configEntry = parseExtensionConfigFile(configPath);
+		const configDir = dirname(configPath);
+		const template = await loadExtensionTemplate(configEntry.path, configDir);
+		const extension = validateExtensionConfig(template, configEntry.config);
+		extensions.push(extension);
 	}
 
 	return extensions;
 }
+
+export { ExtensionConfigValidationError };

--- a/packages/otter-agent-cli/src/main.ts
+++ b/packages/otter-agent-cli/src/main.ts
@@ -1,6 +1,13 @@
-import { AgentEnvironment, type AuthStorage, ModelRegistry } from "@otter-agent/core";
+import type { AgentEnvironment, AuthStorage, SessionManager } from "@otter-agent/core";
+import { ModelRegistry } from "@otter-agent/core";
 import { parseCliArgs, printHelp } from "./args.js";
 import { buildAuthStorageFromEnv } from "./auth.js";
+import {
+	ComponentConfigFileError,
+	ComponentConfigValidationError,
+	ComponentLoadError,
+	loadComponent,
+} from "./load-component.js";
 import { loadExtensionsFromConfigFiles } from "./load-extensions.js";
 import { runRpcMode } from "./rpc/rpc-mode.js";
 
@@ -22,6 +29,31 @@ function resolveModelFromArgs(provider: string, modelId: string, authStorage: Au
 	return model;
 }
 
+/**
+ * Load a component from a config file, exiting on any error.
+ *
+ * @param configPath - Path to the JSON or YAML config file.
+ * @param label - Human-readable label for error messages (e.g. "session manager").
+ */
+async function loadComponentOrExit<T>(configPath: string, label: string): Promise<T> {
+	try {
+		return await loadComponent<T>(configPath);
+	} catch (err) {
+		if (err instanceof ComponentConfigFileError) {
+			console.error(`Error: Failed to load ${label} config file "${configPath}": ${err.message}`);
+		} else if (err instanceof ComponentLoadError) {
+			console.error(`Error: Failed to load ${label} template: ${err.message}`);
+		} else if (err instanceof ComponentConfigValidationError) {
+			console.error(`Error: ${label} config validation failed:\n${err.errors.join("\n")}`);
+		} else {
+			console.error(
+				`Error: Unexpected failure loading ${label}: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+		process.exit(1);
+	}
+}
+
 export async function main(argv: string[]): Promise<void> {
 	const args = parseCliArgs(argv);
 
@@ -35,27 +67,33 @@ export async function main(argv: string[]): Promise<void> {
 		process.exit(0);
 	}
 
-	const apiKeyOverride = args.apiKey ? { provider: args.provider, apiKey: args.apiKey } : undefined;
+	// Load the three required components from their config files.
+	const [sessionManager, environment] = await Promise.all([
+		loadComponentOrExit<SessionManager>(args.sessionManagerConfig, "session manager"),
+		loadComponentOrExit<AgentEnvironment>(args.agentEnvironmentConfig, "agent environment"),
+	]);
 
-	const authStorage = buildAuthStorageFromEnv(apiKeyOverride);
+	// Auth storage: either loaded from a config file or built from env vars / --api-key.
+	let authStorage: AuthStorage;
+	if (args.authStorageConfig) {
+		authStorage = await loadComponentOrExit<AuthStorage>(args.authStorageConfig, "auth storage");
+	} else {
+		const apiKeyOverride = args.apiKey
+			? { provider: args.provider, apiKey: args.apiKey }
+			: undefined;
+		authStorage = buildAuthStorageFromEnv(apiKeyOverride);
+	}
 
 	// Resolve the model from CLI flags before creating the session.
-	// We need a temporary ModelRegistry here because createRpcSession requires a
-	// resolved Model<Api> object, not raw provider/modelId strings. createRpcSession
-	// constructs its own registry internally for session-context resolution — this one
-	// is only used for early CLI validation.
 	const model = resolveModelFromArgs(args.provider, args.model, authStorage);
 
-	const environment = AgentEnvironment.justBash({
-		cwd: args.cwd ?? process.cwd(),
-	});
-
-	// Load extensions from config files (non-fatal: errors are logged as warnings)
+	// Load extensions from config files (fatal: errors throw).
 	const extensions = await loadExtensionsFromConfigFiles(args.extensions);
 
 	await runRpcMode({
 		authStorage,
 		environment,
+		sessionManager,
 		systemPrompt: args.systemPrompt ?? "You are a helpful AI assistant.",
 		model,
 		thinkingLevel: args.thinking,

--- a/packages/otter-agent-cli/src/main.ts
+++ b/packages/otter-agent-cli/src/main.ts
@@ -87,7 +87,7 @@ export async function main(argv: string[]): Promise<void> {
 	// Resolve the model from CLI flags before creating the session.
 	const model = resolveModelFromArgs(args.provider, args.model, authStorage);
 
-	// Load extensions from config files (fatal: errors throw).
+	// Load extensions from config files (non-fatal: errors are logged and skipped).
 	const extensions = await loadExtensionsFromConfigFiles(args.extensions);
 
 	await runRpcMode({

--- a/packages/otter-agent/src/auth-storages/in-memory-auth-storage.ts
+++ b/packages/otter-agent/src/auth-storages/in-memory-auth-storage.ts
@@ -1,4 +1,6 @@
+import { Type } from "@sinclair/typebox";
 import type { AuthStorage } from "../interfaces/auth-storage.js";
+import type { ComponentTemplate } from "../interfaces/component-template.js";
 
 export class InMemoryAuthStorage implements AuthStorage {
 	private readonly keys: ReadonlyMap<string, string>;
@@ -23,3 +25,25 @@ export class InMemoryAuthStorage implements AuthStorage {
 export function createInMemoryAuthStorage(keys?: Record<string, string>): InMemoryAuthStorage {
 	return new InMemoryAuthStorage(keys);
 }
+
+// ─── ComponentTemplate ────────────────────────────────────────────────────────
+
+/** TypeBox schema for {@link InMemoryAuthStorage} options. */
+export const InMemoryAuthStorageOptionsSchema = Type.Object({
+	/** Optional map of provider identifier to API key. */
+	keys: Type.Optional(Type.Record(Type.String(), Type.String())),
+});
+
+/**
+ * {@link ComponentTemplate} for {@link InMemoryAuthStorage}.
+ *
+ * Builds an in-memory auth storage seeded with an optional key map.
+ */
+export const InMemoryAuthStorageTemplate: ComponentTemplate<
+	typeof InMemoryAuthStorageOptionsSchema,
+	InMemoryAuthStorage
+> = {
+	configSchema: () => InMemoryAuthStorageOptionsSchema,
+	defaultConfig: () => ({}),
+	build: ({ keys }) => new InMemoryAuthStorage(keys),
+};

--- a/packages/otter-agent/src/auth-storages/index.ts
+++ b/packages/otter-agent/src/auth-storages/index.ts
@@ -6,10 +6,17 @@ import {
 	createSqliteAuthStorage,
 } from "./sqlite-auth-storage.js";
 
-export { createInMemoryAuthStorage, InMemoryAuthStorage } from "./in-memory-auth-storage.js";
+export {
+	createInMemoryAuthStorage,
+	InMemoryAuthStorage,
+	InMemoryAuthStorageOptionsSchema,
+	InMemoryAuthStorageTemplate,
+} from "./in-memory-auth-storage.js";
 export {
 	createSqliteAuthStorage,
 	SqliteAuthStorage,
+	SqliteAuthStorageOptionsSchema,
+	SqliteAuthStorageTemplate,
 	type SqliteAuthStorageOptions,
 } from "./sqlite-auth-storage.js";
 

--- a/packages/otter-agent/src/auth-storages/sqlite-auth-storage.ts
+++ b/packages/otter-agent/src/auth-storages/sqlite-auth-storage.ts
@@ -1,5 +1,7 @@
 import { Database } from "bun:sqlite";
+import { Type } from "@sinclair/typebox";
 import type { AuthStorage } from "../interfaces/auth-storage.js";
+import type { ComponentTemplate } from "../interfaces/component-template.js";
 
 // ─── Options ─────────────────────────────────────────────────────────────────
 
@@ -146,3 +148,29 @@ export class SqliteAuthStorage implements AuthStorage {
 export function createSqliteAuthStorage(options: SqliteAuthStorageOptions): SqliteAuthStorage {
 	return new SqliteAuthStorage(options);
 }
+
+// ─── ComponentTemplate ────────────────────────────────────────────────────────
+
+/** TypeBox schema for {@link SqliteAuthStorage} options. */
+export const SqliteAuthStorageOptionsSchema = Type.Object({
+	/** Path to the SQLite database file. Created if it doesn't exist. */
+	dbPath: Type.String({ minLength: 1 }),
+	/** Unique storage identifier. Keys are scoped to this ID. */
+	storageId: Type.String({ minLength: 1 }),
+	/** Optional table name. Defaults to "auth_keys". */
+	tableName: Type.Optional(Type.String({ minLength: 1 })),
+});
+
+/**
+ * {@link ComponentTemplate} for {@link SqliteAuthStorage}.
+ *
+ * Builds a SQLite-backed auth storage from a config file.
+ */
+export const SqliteAuthStorageTemplate: ComponentTemplate<
+	typeof SqliteAuthStorageOptionsSchema,
+	SqliteAuthStorage
+> = {
+	configSchema: () => SqliteAuthStorageOptionsSchema,
+	defaultConfig: () => ({ dbPath: "./auth.db", storageId: "default" }),
+	build: (config) => new SqliteAuthStorage(config),
+};

--- a/packages/otter-agent/src/environments/agent-environment.ts
+++ b/packages/otter-agent/src/environments/agent-environment.ts
@@ -2,6 +2,8 @@ import type { AgentEnvironment as IAgentEnvironment } from "../interfaces/agent-
 import {
 	JustBashAgentEnvironment,
 	type JustBashAgentEnvironmentOptions,
+	JustBashAgentEnvironmentOptionsSchema,
+	JustBashAgentEnvironmentTemplate,
 	type JustBashToolName,
 	isJustBashAgentEnvironment,
 } from "./just-bash/just-bash-agent-environment.js";
@@ -9,6 +11,8 @@ import {
 export {
 	isJustBashAgentEnvironment,
 	JustBashAgentEnvironment,
+	JustBashAgentEnvironmentOptionsSchema,
+	JustBashAgentEnvironmentTemplate,
 	type JustBashAgentEnvironmentOptions,
 	type JustBashToolName,
 };

--- a/packages/otter-agent/src/environments/index.ts
+++ b/packages/otter-agent/src/environments/index.ts
@@ -1,6 +1,8 @@
 export {
 	AgentEnvironment,
 	JustBashAgentEnvironment,
+	JustBashAgentEnvironmentOptionsSchema,
+	JustBashAgentEnvironmentTemplate,
 	isJustBashAgentEnvironment,
 	type JustBashAgentEnvironmentOptions,
 	type JustBashToolName,

--- a/packages/otter-agent/src/environments/just-bash/just-bash-agent-environment.ts
+++ b/packages/otter-agent/src/environments/just-bash/just-bash-agent-environment.ts
@@ -1,6 +1,8 @@
+import { Type } from "@sinclair/typebox";
 import { Bash } from "just-bash";
 import type { BashOptions, CommandName, InitialFiles, NetworkConfig } from "just-bash";
 import type { AgentEnvironment } from "../../interfaces/agent-environment.js";
+import type { ComponentTemplate } from "../../interfaces/component-template.js";
 import type { SkillDefinition } from "../../interfaces/skill-definition.js";
 import type { SkillSupportedAgentEnvironment } from "../../interfaces/skill-supported-agent-environment.js";
 import type { ToolDefinition } from "../../interfaces/tool-definition.js";
@@ -289,3 +291,221 @@ export class JustBashAgentEnvironment implements AgentEnvironment, SkillSupporte
 export function isJustBashAgentEnvironment(env: object): env is JustBashAgentEnvironment {
 	return env instanceof JustBashAgentEnvironment;
 }
+
+// ─── ComponentTemplate ────────────────────────────────────────────────────────
+
+/**
+ * TypeBox schema for execution limits. All fields are optional numbers
+ * that override just-bash defaults.
+ */
+const ExecutionLimitsSchema = Type.Object({
+	maxCallDepth: Type.Optional(Type.Number({ minimum: 1 })),
+	maxCommandCount: Type.Optional(Type.Number({ minimum: 1 })),
+	maxLoopIterations: Type.Optional(Type.Number({ minimum: 1 })),
+	maxAwkIterations: Type.Optional(Type.Number({ minimum: 1 })),
+	maxSedIterations: Type.Optional(Type.Number({ minimum: 1 })),
+	maxJqIterations: Type.Optional(Type.Number({ minimum: 1 })),
+	maxSqliteTimeoutMs: Type.Optional(Type.Number({ minimum: 0 })),
+	maxPythonTimeoutMs: Type.Optional(Type.Number({ minimum: 0 })),
+	maxJsTimeoutMs: Type.Optional(Type.Number({ minimum: 0 })),
+	maxGlobOperations: Type.Optional(Type.Number({ minimum: 1 })),
+	maxStringLength: Type.Optional(Type.Number({ minimum: 1 })),
+	maxArrayElements: Type.Optional(Type.Number({ minimum: 1 })),
+	maxHeredocSize: Type.Optional(Type.Number({ minimum: 1 })),
+	maxSubstitutionDepth: Type.Optional(Type.Number({ minimum: 1 })),
+	maxBraceExpansionResults: Type.Optional(Type.Number({ minimum: 1 })),
+	maxOutputSize: Type.Optional(Type.Number({ minimum: 1 })),
+	maxFileDescriptors: Type.Optional(Type.Number({ minimum: 1 })),
+	maxSourceDepth: Type.Optional(Type.Number({ minimum: 1 })),
+});
+
+/**
+ * TypeBox schema for network configuration.
+ *
+ * Note: `allowedUrlPrefixes` supports only plain string entries when loaded
+ * from a config file. The `AllowedUrl` object form (with transforms for
+ * secrets brokering) requires programmatic construction.
+ */
+const NetworkConfigSchema = Type.Object({
+	allowedUrlPrefixes: Type.Optional(Type.Array(Type.String())),
+	allowedMethods: Type.Optional(
+		Type.Array(
+			Type.Union([
+				Type.Literal("GET"),
+				Type.Literal("HEAD"),
+				Type.Literal("POST"),
+				Type.Literal("PUT"),
+				Type.Literal("DELETE"),
+				Type.Literal("PATCH"),
+				Type.Literal("OPTIONS"),
+			]),
+		),
+	),
+	dangerouslyAllowFullInternetAccess: Type.Optional(Type.Boolean()),
+	maxRedirects: Type.Optional(Type.Number({ minimum: 0 })),
+	timeoutMs: Type.Optional(Type.Number({ minimum: 0 })),
+	maxResponseSize: Type.Optional(Type.Number({ minimum: 1 })),
+	denyPrivateRanges: Type.Optional(Type.Boolean()),
+});
+
+/** All valid just-bash built-in command names. */
+const CommandNameLiterals = [
+	"echo",
+	"cat",
+	"printf",
+	"ls",
+	"mkdir",
+	"rmdir",
+	"touch",
+	"rm",
+	"cp",
+	"mv",
+	"ln",
+	"chmod",
+	"pwd",
+	"readlink",
+	"head",
+	"tail",
+	"wc",
+	"stat",
+	"grep",
+	"fgrep",
+	"egrep",
+	"rg",
+	"sed",
+	"awk",
+	"sort",
+	"uniq",
+	"comm",
+	"cut",
+	"paste",
+	"tr",
+	"rev",
+	"nl",
+	"fold",
+	"expand",
+	"unexpand",
+	"strings",
+	"split",
+	"column",
+	"join",
+	"tee",
+	"find",
+	"basename",
+	"dirname",
+	"tree",
+	"du",
+	"env",
+	"printenv",
+	"alias",
+	"unalias",
+	"history",
+	"xargs",
+	"true",
+	"false",
+	"clear",
+	"bash",
+	"sh",
+	"jq",
+	"base64",
+	"diff",
+	"date",
+	"sleep",
+	"timeout",
+	"seq",
+	"expr",
+	"md5sum",
+	"sha1sum",
+	"sha256sum",
+	"file",
+	"html-to-markdown",
+	"help",
+	"which",
+	"tac",
+	"hostname",
+	"od",
+	"gzip",
+	"gunzip",
+	"zcat",
+	"tar",
+	"yq",
+	"xan",
+	"sqlite3",
+	"time",
+	"whoami",
+] as const satisfies CommandName[];
+
+/** TypeBox schema for {@link JustBashAgentEnvironment} options. */
+export const JustBashAgentEnvironmentOptionsSchema = Type.Object({
+	/** Working directory for relative path resolution. Default: "/" */
+	cwd: Type.Optional(Type.String()),
+	/** Environment variables available to shell commands. */
+	env: Type.Optional(Type.Record(Type.String(), Type.String())),
+	/**
+	 * Tools to expose to the agent. When omitted, all four tools are included.
+	 *
+	 * @example ["bash", "read"]
+	 */
+	tools: Type.Optional(
+		Type.Array(
+			Type.Union([
+				Type.Literal("bash"),
+				Type.Literal("read"),
+				Type.Literal("write"),
+				Type.Literal("edit"),
+			]),
+		),
+	),
+	/**
+	 * Allowlist of built-in command names. All built-ins enabled when omitted.
+	 * Use to restrict which shell commands are available.
+	 */
+	commands: Type.Optional(
+		Type.Array(
+			Type.Union(
+				CommandNameLiterals.map((n) => Type.Literal(n)) as [
+					ReturnType<typeof Type.Literal>,
+					...ReturnType<typeof Type.Literal>[],
+				],
+			),
+		),
+	),
+	/**
+	 * Initial files to seed the virtual filesystem.
+	 *
+	 * Only string file content is supported when loading from a config file.
+	 * Binary content requires programmatic construction.
+	 */
+	files: Type.Optional(Type.Record(Type.String(), Type.String())),
+	/** Execution limits to prevent runaway compute. */
+	executionLimits: Type.Optional(ExecutionLimitsSchema),
+	/**
+	 * Network configuration. Network access is disabled by default.
+	 * Only plain string URL prefixes are supported via config file.
+	 */
+	network: Type.Optional(NetworkConfigSchema),
+});
+
+/**
+ * {@link ComponentTemplate} for {@link JustBashAgentEnvironment}.
+ *
+ * Builds a sandboxed just-bash environment from a config file.
+ */
+export const JustBashAgentEnvironmentTemplate: ComponentTemplate<
+	typeof JustBashAgentEnvironmentOptionsSchema,
+	JustBashAgentEnvironment
+> = {
+	configSchema: () => JustBashAgentEnvironmentOptionsSchema,
+	defaultConfig: () => ({}),
+	build: (config) => {
+		const opts: JustBashAgentEnvironmentOptions = {};
+		if (config.cwd !== undefined) opts.cwd = config.cwd;
+		if (config.env !== undefined) opts.env = config.env;
+		if (config.tools !== undefined) opts.tools = config.tools as JustBashToolName[];
+		if (config.commands !== undefined) opts.commands = config.commands as CommandName[];
+		if (config.files !== undefined) opts.files = config.files as InitialFiles;
+		if (config.executionLimits !== undefined) opts.executionLimits = config.executionLimits;
+		if (config.network !== undefined) opts.network = config.network as NetworkConfig;
+		return new JustBashAgentEnvironment(opts);
+	},
+};

--- a/packages/otter-agent/src/extension-core/index.ts
+++ b/packages/otter-agent/src/extension-core/index.ts
@@ -46,6 +46,11 @@ export {
 	validateExtensionConfig,
 	validateExtensionConfigOnly,
 } from "./validate-extension-config.js";
+export {
+	ComponentConfigValidationError,
+	validateComponentConfig,
+	validateComponentConfigOnly,
+} from "./validate-component-config.js";
 export type { ExtensionRunnerActions } from "./extension-runner.js";
 export type { ExtensionHandler, ExtensionsAPI, ToolInfo } from "./extensions-api.js";
 export type { ProviderConfig, ProviderModelConfig } from "./providers.js";

--- a/packages/otter-agent/src/extension-core/validate-component-config.test.ts
+++ b/packages/otter-agent/src/extension-core/validate-component-config.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+import { Type } from "@sinclair/typebox";
+import type { ComponentTemplate } from "../interfaces/component-template.js";
+import {
+	ComponentConfigValidationError,
+	validateComponentConfig,
+	validateComponentConfigOnly,
+} from "./validate-component-config.js";
+
+function createTestTemplate(overrides?: {
+	defaultConfig?: Record<string, unknown>;
+	build?: (config: Record<string, unknown>) => { id: string };
+}): ComponentTemplate {
+	const schema = Type.Object({
+		apiKey: Type.String(),
+		maxRetries: Type.Number(),
+		enabled: Type.Boolean(),
+		nested: Type.Object({
+			host: Type.String(),
+			port: Type.Number(),
+		}),
+	});
+
+	const defaultConfig = overrides?.defaultConfig ?? {
+		apiKey: "",
+		maxRetries: 3,
+		enabled: true,
+		nested: { host: "localhost", port: 5432 },
+	};
+
+	const build = overrides?.build ?? ((config) => ({ id: config.apiKey }));
+
+	return {
+		configSchema: () => schema,
+		defaultConfig: () => defaultConfig,
+		build: build as (config: never) => { id: string },
+	};
+}
+
+describe("validateComponentConfig", () => {
+	test("returns a built component with valid config overrides", () => {
+		const template = createTestTemplate();
+		const instance = validateComponentConfig(template, { apiKey: "sk-test" });
+
+		expect(instance).toEqual({ id: "sk-test" });
+	});
+
+	test("uses defaults when no rawConfig provided", () => {
+		let receivedConfig: Record<string, unknown> | undefined;
+		const template = createTestTemplate({
+			build: (config) => {
+				receivedConfig = config;
+				return { id: "captured" };
+			},
+		});
+
+		validateComponentConfig(template);
+
+		expect(receivedConfig).toEqual({
+			apiKey: "",
+			maxRetries: 3,
+			enabled: true,
+			nested: { host: "localhost", port: 5432 },
+		});
+	});
+
+	test("deep merges nested config objects", () => {
+		let receivedConfig: Record<string, unknown> | undefined;
+		const template = createTestTemplate({
+			build: (config) => {
+				receivedConfig = config;
+				return { id: "captured" };
+			},
+		});
+
+		validateComponentConfig(template, { nested: { port: 3306 } });
+
+		// host should be preserved from defaults, port overridden
+		expect(receivedConfig?.nested).toEqual({ host: "localhost", port: 3306 });
+	});
+
+	test("throws ComponentConfigValidationError for invalid config", () => {
+		const template = createTestTemplate();
+
+		expect(() =>
+			validateComponentConfig(template, {
+				apiKey: "sk-test",
+				maxRetries: "not-a-number",
+			}),
+		).toThrow(ComponentConfigValidationError);
+	});
+
+	test("error message includes validation details", () => {
+		const template = createTestTemplate();
+
+		try {
+			validateComponentConfig(template, { apiKey: "sk-test", maxRetries: "not-a-number" });
+			expect.unreachable("Should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ComponentConfigValidationError);
+			const validationErr = err as ComponentConfigValidationError;
+			expect(validationErr.name).toBe("ComponentConfigValidationError");
+			expect(validationErr.errors.length).toBeGreaterThan(0);
+			expect(validationErr.template).toBe(template);
+			expect(validationErr.message).toContain("validation failed");
+		}
+	});
+
+	test("extra properties at top level do not cause validation error", () => {
+		const template = createTestTemplate();
+		// TypeBox allows additional properties by default
+		const instance = validateComponentConfig(template, {
+			apiKey: "sk-test",
+			unknownField: "ignored",
+		});
+		expect(instance).toEqual({ id: "sk-test" });
+	});
+
+	test("deep merge provides missing nested required fields from defaults", () => {
+		let receivedConfig: Record<string, unknown> | undefined;
+		const template = createTestTemplate({
+			build: (config) => {
+				receivedConfig = config;
+				return { id: "captured" };
+			},
+		});
+
+		validateComponentConfig(template, { nested: { host: "localhost" } });
+
+		expect(receivedConfig?.nested).toEqual({ host: "localhost", port: 5432 });
+	});
+
+	test("partial config merges with defaults for the rest", () => {
+		let receivedConfig: Record<string, unknown> | undefined;
+		const template = createTestTemplate({
+			build: (config) => {
+				receivedConfig = config;
+				return { id: "captured" };
+			},
+		});
+
+		validateComponentConfig(template, { apiKey: "sk-test" });
+
+		expect(receivedConfig).toEqual({
+			apiKey: "sk-test",
+			maxRetries: 3,
+			enabled: true,
+			nested: { host: "localhost", port: 5432 },
+		});
+	});
+});
+
+describe("validateComponentConfigOnly", () => {
+	test("returns validated config without building component", () => {
+		const template = createTestTemplate();
+		const config = validateComponentConfigOnly(template, { apiKey: "sk-test" });
+
+		expect(config).toEqual({
+			apiKey: "sk-test",
+			maxRetries: 3,
+			enabled: true,
+			nested: { host: "localhost", port: 5432 },
+		});
+	});
+
+	test("throws validation error for invalid config", () => {
+		const template = createTestTemplate();
+
+		expect(() => validateComponentConfigOnly(template, { apiKey: 12345 })).toThrow(
+			ComponentConfigValidationError,
+		);
+	});
+
+	test("returns defaults when no rawConfig provided", () => {
+		const template = createTestTemplate();
+		const config = validateComponentConfigOnly(template);
+
+		expect(config).toEqual({
+			apiKey: "",
+			maxRetries: 3,
+			enabled: true,
+			nested: { host: "localhost", port: 5432 },
+		});
+	});
+
+	test("deep merges nested config", () => {
+		const template = createTestTemplate();
+		const config = validateComponentConfigOnly(template, { nested: { port: 3306 } });
+
+		expect(config.nested).toEqual({ host: "localhost", port: 3306 });
+	});
+});
+
+describe("ComponentConfigValidationError", () => {
+	test("has correct name and properties", () => {
+		const template = createTestTemplate();
+		const error = new ComponentConfigValidationError(template, [
+			"/apiKey: Expected string",
+			"/maxRetries: Expected number",
+		]);
+
+		expect(error.name).toBe("ComponentConfigValidationError");
+		expect(error.template).toBe(template);
+		expect(error.errors).toEqual(["/apiKey: Expected string", "/maxRetries: Expected number"]);
+		expect(error.message).toContain("/apiKey: Expected string");
+		expect(error.message).toContain("/maxRetries: Expected number");
+	});
+
+	test("is instanceof Error", () => {
+		const template = createTestTemplate();
+		const error = new ComponentConfigValidationError(template, ["test"]);
+
+		expect(error).toBeInstanceOf(Error);
+	});
+});

--- a/packages/otter-agent/src/extension-core/validate-component-config.ts
+++ b/packages/otter-agent/src/extension-core/validate-component-config.ts
@@ -1,6 +1,7 @@
 import type { Static, TSchema } from "@sinclair/typebox";
 import { TypeCompiler } from "@sinclair/typebox/compiler";
 import type { ComponentTemplate } from "../interfaces/component-template.js";
+import { deepMerge } from "../utils/deep-merge.js";
 
 /**
  * Error thrown when component config validation fails.
@@ -76,31 +77,4 @@ function mergeAndValidate<TConfig extends TSchema, TInstance>(
 	}
 
 	return merged;
-}
-
-function deepMerge(target: unknown, source: unknown): unknown {
-	if (typeof source !== "object" || source === null || Array.isArray(source)) {
-		return source;
-	}
-	if (typeof target !== "object" || target === null || Array.isArray(target)) {
-		return source;
-	}
-	const result = { ...target };
-	for (const key of Object.keys(source as Record<string, unknown>)) {
-		const sourceVal = (source as Record<string, unknown>)[key];
-		const targetVal = (target as Record<string, unknown>)[key];
-		if (
-			typeof sourceVal === "object" &&
-			sourceVal !== null &&
-			!Array.isArray(sourceVal) &&
-			typeof targetVal === "object" &&
-			targetVal !== null &&
-			!Array.isArray(targetVal)
-		) {
-			(result as Record<string, unknown>)[key] = deepMerge(targetVal, sourceVal);
-		} else {
-			(result as Record<string, unknown>)[key] = sourceVal;
-		}
-	}
-	return result;
 }

--- a/packages/otter-agent/src/extension-core/validate-component-config.ts
+++ b/packages/otter-agent/src/extension-core/validate-component-config.ts
@@ -1,0 +1,106 @@
+import type { Static, TSchema } from "@sinclair/typebox";
+import { TypeCompiler } from "@sinclair/typebox/compiler";
+import type { ComponentTemplate } from "../interfaces/component-template.js";
+
+/**
+ * Error thrown when component config validation fails.
+ */
+export class ComponentConfigValidationError extends Error {
+	constructor(
+		public readonly template: ComponentTemplate,
+		public readonly errors: string[],
+	) {
+		super(`Component config validation failed:\n${errors.join("\n")}`);
+		this.name = "ComponentConfigValidationError";
+	}
+}
+
+/**
+ * Validate raw config against a template's schema, merge with defaults,
+ * and build the component instance.
+ *
+ * Workflow:
+ * 1. Start with `template.defaultConfig()`
+ * 2. Deep-merge user-provided `rawConfig` on top
+ * 3. Validate the merged result against `template.configSchema()`
+ * 4. Call `template.build()` with the validated config
+ *
+ * @param template - The component template.
+ * @param rawConfig - User-provided config values. Deep-merged with defaults.
+ * @returns A built component instance.
+ * @throws {ComponentConfigValidationError} If validation fails.
+ */
+export function validateComponentConfig<TConfig extends TSchema, TInstance>(
+	template: ComponentTemplate<TConfig, TInstance>,
+	rawConfig: Partial<Static<TConfig>> = {},
+): TInstance {
+	const merged = mergeAndValidate(template, rawConfig);
+	return template.build(merged);
+}
+
+/**
+ * Validate raw config against a template's schema and return the
+ * validated config without building the component.
+ *
+ * Useful when the caller wants to inspect validated config before
+ * passing it to `build()` manually.
+ *
+ * @param template - The component template.
+ * @param rawConfig - User-provided config values. Deep-merged with defaults.
+ * @returns The validated config matching the schema.
+ * @throws {ComponentConfigValidationError} If validation fails.
+ */
+export function validateComponentConfigOnly<TConfig extends TSchema, TInstance>(
+	template: ComponentTemplate<TConfig, TInstance>,
+	rawConfig: Partial<Static<TConfig>> = {},
+): Static<TConfig> {
+	return mergeAndValidate(template, rawConfig);
+}
+
+function mergeAndValidate<TConfig extends TSchema, TInstance>(
+	template: ComponentTemplate<TConfig, TInstance>,
+	rawConfig: Partial<Static<TConfig>>,
+): Static<TConfig> {
+	const defaults = template.defaultConfig();
+	const schema = template.configSchema();
+
+	// Deep merge: defaults as base, rawConfig overrides
+	const merged = deepMerge(defaults, rawConfig) as Static<TConfig>;
+
+	// Validate against schema
+	const compiler = TypeCompiler.Compile(schema);
+	const errors = [...compiler.Errors(merged)].map((e) => `${e.path}: ${e.message}`);
+
+	if (errors.length > 0) {
+		throw new ComponentConfigValidationError(template, errors);
+	}
+
+	return merged;
+}
+
+function deepMerge(target: unknown, source: unknown): unknown {
+	if (typeof source !== "object" || source === null || Array.isArray(source)) {
+		return source;
+	}
+	if (typeof target !== "object" || target === null || Array.isArray(target)) {
+		return source;
+	}
+	const result = { ...target };
+	for (const key of Object.keys(source as Record<string, unknown>)) {
+		const sourceVal = (source as Record<string, unknown>)[key];
+		const targetVal = (target as Record<string, unknown>)[key];
+		if (
+			typeof sourceVal === "object" &&
+			sourceVal !== null &&
+			!Array.isArray(sourceVal) &&
+			typeof targetVal === "object" &&
+			targetVal !== null &&
+			!Array.isArray(targetVal)
+		) {
+			(result as Record<string, unknown>)[key] = deepMerge(targetVal, sourceVal);
+		} else {
+			(result as Record<string, unknown>)[key] = sourceVal;
+		}
+	}
+	return result;
+}

--- a/packages/otter-agent/src/extension-core/validate-extension-config.ts
+++ b/packages/otter-agent/src/extension-core/validate-extension-config.ts
@@ -1,6 +1,7 @@
 import type { Static, TSchema } from "@sinclair/typebox";
 import { TypeCompiler } from "@sinclair/typebox/compiler";
 import type { ExtensionTemplate } from "../interfaces/extension-template.js";
+import { deepMerge } from "../utils/deep-merge.js";
 import type { Extension } from "./extension.js";
 
 /**
@@ -77,31 +78,4 @@ function mergeAndValidate<TConfig extends TSchema>(
 	}
 
 	return merged;
-}
-
-function deepMerge(target: unknown, source: unknown): unknown {
-	if (typeof source !== "object" || source === null || Array.isArray(source)) {
-		return source;
-	}
-	if (typeof target !== "object" || target === null || Array.isArray(target)) {
-		return source;
-	}
-	const result = { ...target };
-	for (const key of Object.keys(source as Record<string, unknown>)) {
-		const sourceVal = (source as Record<string, unknown>)[key];
-		const targetVal = (target as Record<string, unknown>)[key];
-		if (
-			typeof sourceVal === "object" &&
-			sourceVal !== null &&
-			!Array.isArray(sourceVal) &&
-			typeof targetVal === "object" &&
-			targetVal !== null &&
-			!Array.isArray(targetVal)
-		) {
-			(result as Record<string, unknown>)[key] = deepMerge(targetVal, sourceVal);
-		} else {
-			(result as Record<string, unknown>)[key] = sourceVal;
-		}
-	}
-	return result;
 }

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -1,10 +1,14 @@
 // OtterAgent interfaces
 export type {
+	AgentEnvironmentTemplate,
+	AuthStorageTemplate,
+	ComponentTemplate,
 	Entry,
 	EntryId,
 	ExtensionTemplate,
 	ReadonlySessionManager,
 	SessionContext,
+	SessionManagerTemplate,
 	SkillDefinition,
 	SkillSupportedAgentEnvironment,
 	ToolDefinition,
@@ -18,6 +22,8 @@ export {
 	AgentEnvironment,
 	isJustBashAgentEnvironment,
 	JustBashAgentEnvironment,
+	JustBashAgentEnvironmentOptionsSchema,
+	JustBashAgentEnvironmentTemplate,
 	type JustBashAgentEnvironmentOptions,
 	type JustBashToolName,
 } from "./environments/index.js";
@@ -37,7 +43,11 @@ export {
 export {
 	AuthStorage,
 	InMemoryAuthStorage,
+	InMemoryAuthStorageOptionsSchema,
+	InMemoryAuthStorageTemplate,
 	SqliteAuthStorage,
+	SqliteAuthStorageOptionsSchema,
+	SqliteAuthStorageTemplate,
 	createInMemoryAuthStorage,
 	createSqliteAuthStorage,
 	type SqliteAuthStorageOptions,
@@ -48,10 +58,14 @@ export {
 // (namespace with factory methods) via declaration merging in session-managers/index.ts.
 export {
 	InMemorySessionManager,
+	InMemorySessionManagerOptionsSchema,
+	InMemorySessionManagerTemplate,
 	createInMemorySessionManager,
 	createSqliteSessionManager,
 	SessionManager,
 	SqliteSessionManager,
+	SqliteSessionManagerOptionsSchema,
+	SqliteSessionManagerTemplate,
 	type SqliteSessionManagerOptions,
 } from "./session-managers/index.js";
 
@@ -104,6 +118,9 @@ export type {
 } from "./extension-core/index.js";
 export { createEventBus, ExtensionRunner } from "./extension-core/index.js";
 export {
+	ComponentConfigValidationError,
+	validateComponentConfig,
+	validateComponentConfigOnly,
 	ExtensionConfigValidationError,
 	validateExtensionConfig,
 	validateExtensionConfigOnly,

--- a/packages/otter-agent/src/interfaces/component-template.ts
+++ b/packages/otter-agent/src/interfaces/component-template.ts
@@ -1,0 +1,68 @@
+import type { Static, TSchema } from "@sinclair/typebox";
+import type { AgentEnvironment } from "./agent-environment.js";
+import type { AuthStorage } from "./auth-storage.js";
+import type { SessionManager } from "./session-manager.js";
+
+/**
+ * A configurable factory for building pluggable components.
+ *
+ * Serves all three core pluggable component types: {@link SessionManager},
+ * {@link AuthStorage}, and {@link AgentEnvironment}. Callers validate
+ * user-provided config against the schema, merge with defaults, and call
+ * {@link build} to produce a concrete instance.
+ *
+ * @typeParam TConfig - The TypeBox schema describing the config shape.
+ * @typeParam TInstance - The type of instance produced by {@link build}.
+ */
+export interface ComponentTemplate<TConfig extends TSchema = TSchema, TInstance = unknown> {
+	/**
+	 * Return the TypeBox schema for this template's configuration.
+	 *
+	 * Used by callers (and by {@link validateComponentConfig}) to validate
+	 * user-provided config before passing it to {@link build}.
+	 */
+	configSchema(): TConfig;
+
+	/**
+	 * Return the default configuration values.
+	 *
+	 * Callers should merge user-provided config on top of these defaults
+	 * before calling {@link build}. Templates where every field is required
+	 * should still implement this (returning `{}` cast to the appropriate
+	 * type) so callers can use a uniform pattern.
+	 */
+	defaultConfig(): Static<TConfig>;
+
+	/**
+	 * Build the component instance from a validated config.
+	 *
+	 * The config is consumed at build time — implementations that need
+	 * runtime access should capture it in a closure or store it on the
+	 * constructed instance.
+	 */
+	build(config: Static<TConfig>): TInstance;
+}
+
+/**
+ * Convenience alias: a {@link ComponentTemplate} that produces a {@link SessionManager}.
+ */
+export type SessionManagerTemplate<TConfig extends TSchema = TSchema> = ComponentTemplate<
+	TConfig,
+	SessionManager
+>;
+
+/**
+ * Convenience alias: a {@link ComponentTemplate} that produces an {@link AuthStorage}.
+ */
+export type AuthStorageTemplate<TConfig extends TSchema = TSchema> = ComponentTemplate<
+	TConfig,
+	AuthStorage
+>;
+
+/**
+ * Convenience alias: a {@link ComponentTemplate} that produces an {@link AgentEnvironment}.
+ */
+export type AgentEnvironmentTemplate<TConfig extends TSchema = TSchema> = ComponentTemplate<
+	TConfig,
+	AgentEnvironment
+>;

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -1,6 +1,12 @@
 export type { AgentEnvironment } from "./agent-environment.js";
 export type { AuthStorage } from "./auth-storage.js";
 export type {
+	ComponentTemplate,
+	SessionManagerTemplate,
+	AuthStorageTemplate,
+	AgentEnvironmentTemplate,
+} from "./component-template.js";
+export type {
 	Entry,
 	SessionContext,
 	SessionManager,

--- a/packages/otter-agent/src/session-managers/in-memory-session-manager.ts
+++ b/packages/otter-agent/src/session-managers/in-memory-session-manager.ts
@@ -1,5 +1,7 @@
 import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
+import { Type } from "@sinclair/typebox";
+import type { ComponentTemplate } from "../interfaces/component-template.js";
 import type {
 	Entry,
 	EntryId,
@@ -165,3 +167,22 @@ export class InMemorySessionManager implements SessionManager {
 export function createInMemorySessionManager(): InMemorySessionManager {
 	return new InMemorySessionManager();
 }
+
+// ─── ComponentTemplate ────────────────────────────────────────────────────────
+
+/** TypeBox schema for {@link InMemorySessionManager} options (no configuration needed). */
+export const InMemorySessionManagerOptionsSchema = Type.Object({});
+
+/**
+ * {@link ComponentTemplate} for {@link InMemorySessionManager}.
+ *
+ * No configuration is required. Suitable for testing and short-lived sessions.
+ */
+export const InMemorySessionManagerTemplate: ComponentTemplate<
+	typeof InMemorySessionManagerOptionsSchema,
+	InMemorySessionManager
+> = {
+	configSchema: () => InMemorySessionManagerOptionsSchema,
+	defaultConfig: () => ({}),
+	build: () => new InMemorySessionManager(),
+};

--- a/packages/otter-agent/src/session-managers/index.ts
+++ b/packages/otter-agent/src/session-managers/index.ts
@@ -12,10 +12,14 @@ import {
 export {
 	createInMemorySessionManager,
 	InMemorySessionManager,
+	InMemorySessionManagerOptionsSchema,
+	InMemorySessionManagerTemplate,
 } from "./in-memory-session-manager.js";
 export {
 	createSqliteSessionManager,
 	SqliteSessionManager,
+	SqliteSessionManagerOptionsSchema,
+	SqliteSessionManagerTemplate,
 	type SqliteSessionManagerOptions,
 } from "./sqlite-session-manager.js";
 

--- a/packages/otter-agent/src/session-managers/sqlite-session-manager.ts
+++ b/packages/otter-agent/src/session-managers/sqlite-session-manager.ts
@@ -1,6 +1,8 @@
 import { Database } from "bun:sqlite";
 import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
+import { Type } from "@sinclair/typebox";
+import type { ComponentTemplate } from "../interfaces/component-template.js";
 import type {
 	Entry,
 	EntryId,
@@ -325,3 +327,29 @@ export function createSqliteSessionManager(
 ): SqliteSessionManager {
 	return new SqliteSessionManager(options);
 }
+
+// ─── ComponentTemplate ────────────────────────────────────────────────────────
+
+/** TypeBox schema for {@link SqliteSessionManager} options. */
+export const SqliteSessionManagerOptionsSchema = Type.Object({
+	/** Path to the SQLite database file. Created if it doesn't exist. */
+	dbPath: Type.String({ minLength: 1 }),
+	/** Unique session identifier. Entries are scoped to this ID. */
+	sessionId: Type.String({ minLength: 1 }),
+	/** Optional table name. Defaults to "entries". */
+	tableName: Type.Optional(Type.String({ minLength: 1 })),
+});
+
+/**
+ * {@link ComponentTemplate} for {@link SqliteSessionManager}.
+ *
+ * Builds a SQLite-backed session manager from a config file.
+ */
+export const SqliteSessionManagerTemplate: ComponentTemplate<
+	typeof SqliteSessionManagerOptionsSchema,
+	SqliteSessionManager
+> = {
+	configSchema: () => SqliteSessionManagerOptionsSchema,
+	defaultConfig: () => ({ dbPath: "./sessions.db", sessionId: "default" }),
+	build: (config) => new SqliteSessionManager(config),
+};

--- a/packages/otter-agent/src/utils/deep-merge.ts
+++ b/packages/otter-agent/src/utils/deep-merge.ts
@@ -1,0 +1,34 @@
+/**
+ * Recursively deep-merge `source` into `target`.
+ *
+ * Plain objects are merged key-by-key (source values win).
+ * Arrays, nulls, and non-object values from source replace target values entirely.
+ *
+ * Neither `target` nor `source` is mutated; a new object is returned.
+ */
+export function deepMerge(target: unknown, source: unknown): unknown {
+	if (typeof source !== "object" || source === null || Array.isArray(source)) {
+		return source;
+	}
+	if (typeof target !== "object" || target === null || Array.isArray(target)) {
+		return source;
+	}
+	const result = { ...target };
+	for (const key of Object.keys(source as Record<string, unknown>)) {
+		const sourceVal = (source as Record<string, unknown>)[key];
+		const targetVal = (target as Record<string, unknown>)[key];
+		if (
+			typeof sourceVal === "object" &&
+			sourceVal !== null &&
+			!Array.isArray(sourceVal) &&
+			typeof targetVal === "object" &&
+			targetVal !== null &&
+			!Array.isArray(targetVal)
+		) {
+			(result as Record<string, unknown>)[key] = deepMerge(targetVal, sourceVal);
+		} else {
+			(result as Record<string, unknown>)[key] = sourceVal;
+		}
+	}
+	return result;
+}


### PR DESCRIPTION
## Summary

Closes #87

Allows the RPC agent to be launched with **custom or built-in versions** of its core pluggable components via YAML/JSON config files:

- **SessionManager** — in-memory or SQLite
- **AuthStorage** — env vars, in-memory, or SQLite
- **AgentEnvironment** — JustBash with configurable tools, cwd, env, limits, network, etc.
- **Extensions** — already supported via `-e`/`--extension` (unchanged)

### CLI Usage

```bash
otter \
  --provider anthropic \
  --model claude-sonnet-4-5-20250514 \
  --session-manager-config ./configs/session-manager.yaml \
  --auth-storage-config ./configs/auth-storage.yaml \
  --agent-environment-config ./configs/environment.yaml \
  -e ./configs/my-extension.yaml
```

### Key Changes

- **`ComponentTemplate<T>`** — generic interface (`configSchema()`, `defaultConfig()`, `build()`) for all loadable components
- **Built-in templates** — each implementation (InMemory/SQLite session managers, auth storages, JustBash environment) exports a `ComponentTemplate` with a TypeBox schema
- **`load-component.ts`** — CLI utility to parse config files, resolve template paths, validate config, and build instances
- **`validate-component-config.ts`** — shared deep-merge + TypeBox validation logic
- **CLI args** — `--session-manager-config`, `--auth-storage-config`, `--agent-environment-config` (required); `--auth-storage-config` is mutually exclusive with `--api-key`
- **`--cwd` removed** — working directory is now set via the environment config file

### Design Decisions

| Decision | Choice |
|----------|--------|
| Component resolution | File path (`path:` in config), not a name registry |
| Template interface | Single generic `ComponentTemplate<T>`, not per-type templates |
| Schema validation | TypeBox required on all loadable implementations |
| Extension loading | Non-fatal (skip + warn), per Decision 6 in the issue |
| Component loading | Fatal — agent cannot function without these |

### Files Changed

| Package | File | Action |
|---------|------|--------|
| core | `src/interfaces/component-template.ts` | New |
| core | `src/extension-core/validate-component-config.ts` | New |
| core | `src/extension-core/validate-component-config.test.ts` | New |
| core | `src/utils/deep-merge.ts` | New |
| core | `src/interfaces/index.ts` | Update |
| core | `src/index.ts` | Update |
| core | `src/extension-core/index.ts` | Update |
| core | `src/session-managers/sqlite-session-manager.ts` | Update |
| core | `src/session-managers/in-memory-session-manager.ts` | Update |
| core | `src/session-managers/index.ts` | Update |
| core | `src/auth-storages/sqlite-auth-storage.ts` | Update |
| core | `src/auth-storages/in-memory-auth-storage.ts` | Update |
| core | `src/auth-storages/index.ts` | Update |
| core | `src/environments/just-bash/just-bash-agent-environment.ts` | Update |
| core | `src/environments/index.ts` | Update |
| core | `src/extension-core/validate-extension-config.ts` | Update (shared deepMerge) |
| cli | `src/load-component.ts` | New |
| cli | `src/load-component.test.ts` | New |
| cli | `src/fixtures/valid-session-manager.ts` | New |
| cli | `src/fixtures/valid-session-manager.json` | New |
| cli | `src/load-extensions.ts` | Refactor (delegates to shared utils) |
| cli | `src/load-extensions.test.ts` | Update |
| cli | `src/args.ts` | Update |
| cli | `src/args.test.ts` | Update |
| cli | `src/main.ts` | Update |

### Test Results

- **633 tests pass** across all 3 packages
- Build clean
- Lint clean (only pre-existing unrelated issues in `.pi/extensions/`)