### PR TITLE
feat: make @otter-agent/core consumable as a dependency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 BowerJames
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 BowerJames
+Copyright (c) 2025-2026 BowerJames
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/otter-agent/README.md
+++ b/packages/otter-agent/README.md
@@ -1,0 +1,149 @@
+# @otter-agent/core
+
+An extensible AI agent framework for building conversational agents with pluggable environments, session management, and extensions.
+
+Built on top of [`@mariozechner/pi-agent-core`](https://github.com/mariozechner/pi-coding-agent) and [`@mariozechner/pi-ai`](https://github.com/mariozechner/pi-coding-agent).
+
+## Installation
+
+### npm (from registry)
+
+Requires an npm account with access to the `@otter-agent` scope.
+
+```bash
+npm install @otter-agent/core
+```
+
+### GitHub dependency (works without an npm account)
+
+```bash
+npm install github:BowerJames/OtterAgent#packages/otter-agent
+```
+
+npm runs the `prepare` script automatically after install, which builds the package. **Bun users** must build manually:
+
+```bash
+bun install
+bun run build
+```
+
+### Local / monorepo workspace
+
+In your `package.json`:
+
+```json
+{
+  "dependencies": {
+    "@otter-agent/core": "workspace:*"
+  }
+}
+```
+
+## Quick Start
+
+```typescript
+import {
+  createInMemorySessionManager,
+  createInMemoryAuthStorage,
+  AgentEnvironment,
+  createAgentSession,
+} from "@otter-agent/core";
+import { Anthropic } from "@mariozechner/pi-ai/anthropic";
+
+// 1. Create pluggable components
+const sessionManager = createInMemorySessionManager();
+const authStorage = createInMemoryAuthStorage({
+  apiKeys: { anthropic: process.env.ANTHROPIC_API_KEY! },
+});
+const environment = AgentEnvironment.justBash({ cwd: "/workspace" });
+
+// 2. Create an agent session
+const { session } = await createAgentSession({
+  sessionManager,
+  authStorage,
+  environment,
+  systemPrompt: "You are a helpful assistant.",
+});
+
+// 3. Subscribe to events
+session.subscribe((event) => {
+  if (event.type === "message_update") {
+    process.stdout.write(event.delta?.text ?? "");
+  }
+});
+
+// 4. Send a prompt
+await session.prompt("Hello! What can you do?");
+```
+
+## Core Concepts
+
+### Pluggable Components
+
+Everything is an interface — swap implementations to match your use case:
+
+| Interface | Built-in implementations | Purpose |
+|---|---|---|
+| `SessionManager` | `InMemorySessionManager`, `SqliteSessionManager` | Persists conversation history |
+| `AuthStorage` | `InMemoryAuthStorage`, `SqliteAuthStorage` | Retrieves API keys |
+| `AgentEnvironment` | `JustBashAgentEnvironment` | Provides tools and environment context |
+| `UIProvider` | `NoOpUIProvider`, `RpcUIProvider` | Extension-to-user interaction |
+
+Each built-in has a `ComponentTemplate` for config-driven instantiation.
+
+### Extensions
+
+Extensions hook into the agent lifecycle via events, register tools and commands, and communicate with each other:
+
+```typescript
+import type { Extension } from "@otter-agent/core";
+
+const myExtension: Extension = (api) => {
+  api.on("session_start", () => {
+    console.log("Agent session started!");
+  });
+
+  api.registerTool({
+    name: "my_tool",
+    label: "My Tool",
+    description: "Does something useful.",
+    parameters: { type: "object", properties: {} },
+    execute: async (id, params, signal) => ({
+      content: [{ type: "text", text: "Result!" }],
+    }),
+  });
+};
+```
+
+### RPC Mode
+
+Run the agent as a headless service over JSON-RPC:
+
+```typescript
+import { createRpcSession, StdioTransport } from "@otter-agent/core";
+
+const { handler } = await createRpcSession({
+  transport: new StdioTransport(() => handler.requestShutdown()),
+  sessionManager,
+  authStorage,
+  environment,
+  model,
+  systemPrompt: "You are a helpful assistant.",
+});
+
+handler.start();
+```
+
+Or use the bundled CLI:
+
+```bash
+otter \
+  --provider anthropic \
+  --model claude-sonnet-4-20250514 \
+  --session-manager in-memory \
+  --agent-environment just-bash
+```
+
+## License
+
+MIT

--- a/packages/otter-agent/README.md
+++ b/packages/otter-agent/README.md
@@ -48,12 +48,11 @@ import {
   AgentEnvironment,
   createAgentSession,
 } from "@otter-agent/core";
-import { Anthropic } from "@mariozechner/pi-ai/anthropic";
 
 // 1. Create pluggable components
 const sessionManager = createInMemorySessionManager();
 const authStorage = createInMemoryAuthStorage({
-  apiKeys: { anthropic: process.env.ANTHROPIC_API_KEY! },
+  anthropic: process.env.ANTHROPIC_API_KEY!,
 });
 const environment = AgentEnvironment.justBash({ cwd: "/workspace" });
 
@@ -67,8 +66,8 @@ const { session } = await createAgentSession({
 
 // 3. Subscribe to events
 session.subscribe((event) => {
-  if (event.type === "message_update") {
-    process.stdout.write(event.delta?.text ?? "");
+  if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+    process.stdout.write(event.assistantMessageEvent.delta);
   }
 });
 
@@ -108,7 +107,7 @@ const myExtension: Extension = (api) => {
     label: "My Tool",
     description: "Does something useful.",
     parameters: { type: "object", properties: {} },
-    execute: async (id, params, signal) => ({
+    execute: async (id, params, signal, onUpdate) => ({
       content: [{ type: "text", text: "Result!" }],
     }),
   });
@@ -120,10 +119,16 @@ const myExtension: Extension = (api) => {
 Run the agent as a headless service over JSON-RPC:
 
 ```typescript
-import { createRpcSession, StdioTransport } from "@otter-agent/core";
+import { createRpcSession, RpcTransport } from "@otter-agent/core";
+
+// Implement RpcTransport to connect to your frontend (TUI, web UI, etc.)
+const transport: RpcTransport = {
+  send(message) { /* send to client */ },
+  onMessage(handler) { /* listen for client messages */ },
+};
 
 const { handler } = await createRpcSession({
-  transport: new StdioTransport(() => handler.requestShutdown()),
+  transport,
   sessionManager,
   authStorage,
   environment,

--- a/packages/otter-agent/package.json
+++ b/packages/otter-agent/package.json
@@ -13,12 +13,14 @@
 			"import": "./dist/index.js"
 		}
 	},
+	"files": ["dist/", "README.md", "LICENSE"],
 	"scripts": {
 		"clean": "rm -rf dist",
 		"prebuild": "bun run clean",
 		"build": "tsc",
 		"test": "bun test",
-		"dev": "tsc --watch"
+		"dev": "tsc --watch",
+		"prepare": "tsc"
 	},
 	"dependencies": {
 		"@mariozechner/pi-agent-core": "^0.64.0",


### PR DESCRIPTION
## Summary

Makes `@otter-agent/core` installable as a dependency in other projects via npm, GitHub URL, or workspace link.

Closes #93

## Changes

### `packages/otter-agent/package.json`
- Added `"files": ["dist/", "README.md", "LICENSE"]` — explicitly whitelists what ships in the npm tarball, preventing source files, tests, and fixtures from leaking.
- Added `"prepare": "tsc"` — npm runs this automatically after cloning/installing from a GitHub URL, so consumers get a built `dist/` without manual steps. Bun consumers need to run `bun run build` once (bun skips `prepare` by design).

### `packages/otter-agent/README.md` (new)
- Package description and links to upstream dependencies.
- Installation instructions for all three consumption methods: npm, GitHub URL, and local workspace.
- Quick-start example showing session creation with in-memory components.
- Core concepts overview covering pluggable components, extensions, and RPC mode.
- CLI usage example.

### `LICENSE` (new, repo root)
- MIT license, required for npm publishing and for downstream consumers.

## Verification

- ✅ All 596 tests pass (556 in `@otter-agent/core`, 40 in `@otter-agent/extension-registry`)
- ✅ Biome lint/format clean (107 files)
- ✅ All packages build cleanly
- ✅ `npm pack --dry-run` confirms only `dist/`, `README.md`, `LICENSE` ship
- ✅ Independent code review passed (2 rounds)