### PR TITLE
feat: add ResourceLoader interface and createAgentSessionFromResourceLoader factory

### DIFF
--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -6,6 +6,7 @@ export type {
 	Entry,
 	EntryId,
 	ReadonlySessionManager,
+	ResourceLoader,
 	SessionContext,
 	SessionManagerTemplate,
 	SkillDefinition,
@@ -126,10 +127,10 @@ export {
 export {
 	AgentSession,
 	buildSystemPrompt,
-	createAgentSession,
-	createAgentSessionFromResourceLoader,
 	buildToolSection,
 	convertToLlm,
+	createAgentSession,
+	createAgentSessionFromResourceLoader,
 	createCompactionSummaryMessage,
 	createCustomMessage,
 	ModelRegistry,
@@ -142,7 +143,6 @@ export type {
 	CompactionSummaryMessage,
 	CreateAgentSessionOptions,
 	CreateAgentSessionResult,
-	ResourceLoader,
 	CustomMessage,
 } from "./session/index.js";
 

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -6,7 +6,6 @@ export type {
 	Entry,
 	EntryId,
 	ReadonlySessionManager,
-	ResourceLoader,
 	SessionContext,
 	SessionManagerTemplate,
 	SkillDefinition,
@@ -127,10 +126,10 @@ export {
 export {
 	AgentSession,
 	buildSystemPrompt,
+	createAgentSession,
 	createAgentSessionFromResourceLoader,
 	buildToolSection,
 	convertToLlm,
-	createAgentSession,
 	createCompactionSummaryMessage,
 	createCustomMessage,
 	ModelRegistry,
@@ -143,6 +142,7 @@ export type {
 	CompactionSummaryMessage,
 	CreateAgentSessionOptions,
 	CreateAgentSessionResult,
+	ResourceLoader,
 	CustomMessage,
 } from "./session/index.js";
 

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -6,6 +6,7 @@ export type {
 	Entry,
 	EntryId,
 	ReadonlySessionManager,
+	ResourceLoader,
 	SessionContext,
 	SessionManagerTemplate,
 	SkillDefinition,
@@ -126,6 +127,7 @@ export {
 export {
 	AgentSession,
 	buildSystemPrompt,
+	createAgentSessionFromResourceLoader,
 	buildToolSection,
 	convertToLlm,
 	createAgentSession,

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -17,4 +17,5 @@ export type { SkillDefinition } from "./skill-definition.js";
 export type { SkillSupportedAgentEnvironment } from "./skill-supported-agent-environment.js";
 export { isSkillSupportedAgentEnvironment } from "./skill-supported-agent-environment.js";
 export type { ToolDefinition } from "./tool-definition.js";
+export type { ResourceLoader } from "./resource-loader.js";
 export type { UIProvider } from "./ui-provider.js";

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -17,5 +17,4 @@ export type { SkillDefinition } from "./skill-definition.js";
 export type { SkillSupportedAgentEnvironment } from "./skill-supported-agent-environment.js";
 export { isSkillSupportedAgentEnvironment } from "./skill-supported-agent-environment.js";
 export type { ToolDefinition } from "./tool-definition.js";
-export type { ResourceLoader } from "./resource-loader.js";
 export type { UIProvider } from "./ui-provider.js";

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -13,6 +13,7 @@ export type {
 	ReadonlySessionManager,
 	EntryId,
 } from "./session-manager.js";
+export type { ResourceLoader } from "./resource-loader.js";
 export type { SkillDefinition } from "./skill-definition.js";
 export type { SkillSupportedAgentEnvironment } from "./skill-supported-agent-environment.js";
 export { isSkillSupportedAgentEnvironment } from "./skill-supported-agent-environment.js";

--- a/packages/otter-agent/src/interfaces/resource-loader.ts
+++ b/packages/otter-agent/src/interfaces/resource-loader.ts
@@ -1,0 +1,18 @@
+import type { CreateAgentSessionOptions } from "../session/agent-session.js";
+
+/**
+ * Provides the resources needed to create an agent session.
+ *
+ * Implementations may load components from config files, construct them
+ * programmatically, or compose them from any source. The only field not
+ * provided is {@link UIProvider}, which is supplied separately by the caller.
+ */
+export interface ResourceLoader {
+	/**
+	 * Load and return all session resources.
+	 *
+	 * @returns An object satisfying {@link CreateAgentSessionOptions}
+	 *          minus {@link UIProvider}.
+	 */
+	getResources(): Promise<Omit<CreateAgentSessionOptions, "uiProvider">>;
+}

--- a/packages/otter-agent/src/interfaces/resource-loader.ts
+++ b/packages/otter-agent/src/interfaces/resource-loader.ts
@@ -1,4 +1,4 @@
-import type { CreateAgentSessionOptions } from "./agent-session.js";
+import type { CreateAgentSessionOptions } from "../session/agent-session.js";
 
 /**
  * Provides the resources needed to create an agent session.

--- a/packages/otter-agent/src/session/agent-session-from-resource-loader.test.ts
+++ b/packages/otter-agent/src/session/agent-session-from-resource-loader.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
+import type { ResourceLoader } from "../interfaces/resource-loader.js";
 import type { SessionManager } from "../interfaces/session-manager.js";
 import type { UIProvider } from "../interfaces/ui-provider.js";
 import { createAgentSessionFromResourceLoader } from "./agent-session.js";
-import type { ResourceLoader } from "./resource-loader.js";
 
 // ─── Test Helpers ─────────────────────────────────────────────────────
 
@@ -74,7 +74,7 @@ describe("createAgentSessionFromResourceLoader", () => {
 		expect(resourceLoader.getResources).toHaveBeenCalledOnce();
 	});
 
-	test("forwards optional fields (model, thinkingLevel, extensions) to the session", async () => {
+	test("forwards optional fields (thinkingLevel, extensions) to the session", async () => {
 		const uiProvider = createMockUIProvider();
 		const mockExtension = vi.fn();
 		const resources = {
@@ -90,7 +90,10 @@ describe("createAgentSessionFromResourceLoader", () => {
 		const result = await createAgentSessionFromResourceLoader(resourceLoader, uiProvider);
 
 		expect(result.session).toBeDefined();
-		expect(result.session.uiProvider).toBe(uiProvider);
+		// No model resolved, so thinkingLevel is kept as provided
+		expect(result.session.agent.state.thinkingLevel).toBe("low");
+		// Verify the resources were passed through to createAgentSession
+		expect(resourceLoader.getResources).toHaveBeenCalledOnce();
 	});
 
 	test("propagates errors from getResources()", async () => {

--- a/packages/otter-agent/src/session/agent-session-from-resource-loader.test.ts
+++ b/packages/otter-agent/src/session/agent-session-from-resource-loader.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
-import type { ResourceLoader } from "../interfaces/resource-loader.js";
 import type { SessionManager } from "../interfaces/session-manager.js";
 import type { UIProvider } from "../interfaces/ui-provider.js";
 import { createAgentSessionFromResourceLoader } from "./agent-session.js";
+import type { ResourceLoader } from "./resource-loader.js";
 
 // ─── Test Helpers ─────────────────────────────────────────────────────
 
@@ -47,22 +47,24 @@ function createMockUIProvider(): UIProvider {
 	};
 }
 
+function createBaseResources() {
+	return {
+		sessionManager: createMockSessionManager(),
+		authStorage: createMockAuthStorage(),
+		environment: createMockEnvironment(),
+		systemPrompt: "You are a test agent.",
+	};
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────
 
 describe("createAgentSessionFromResourceLoader", () => {
 	test("creates a session with resources from the loader and the provided UIProvider", async () => {
-		const sessionManager = createMockSessionManager();
-		const authStorage = createMockAuthStorage();
-		const environment = createMockEnvironment();
 		const uiProvider = createMockUIProvider();
+		const resources = createBaseResources();
 
 		const resourceLoader: ResourceLoader = {
-			getResources: vi.fn(async () => ({
-				sessionManager,
-				authStorage,
-				environment,
-				systemPrompt: "You are a test agent.",
-			})),
+			getResources: vi.fn(async () => resources),
 		};
 
 		const result = await createAgentSessionFromResourceLoader(resourceLoader, uiProvider);
@@ -70,6 +72,25 @@ describe("createAgentSessionFromResourceLoader", () => {
 		expect(result.session).toBeDefined();
 		expect(result.session.uiProvider).toBe(uiProvider);
 		expect(resourceLoader.getResources).toHaveBeenCalledOnce();
+	});
+
+	test("forwards optional fields (model, thinkingLevel, extensions) to the session", async () => {
+		const uiProvider = createMockUIProvider();
+		const mockExtension = vi.fn();
+		const resources = {
+			...createBaseResources(),
+			thinkingLevel: "low" as const,
+			extensions: [mockExtension],
+		};
+
+		const resourceLoader: ResourceLoader = {
+			getResources: vi.fn(async () => resources),
+		};
+
+		const result = await createAgentSessionFromResourceLoader(resourceLoader, uiProvider);
+
+		expect(result.session).toBeDefined();
+		expect(result.session.uiProvider).toBe(uiProvider);
 	});
 
 	test("propagates errors from getResources()", async () => {
@@ -84,30 +105,5 @@ describe("createAgentSessionFromResourceLoader", () => {
 		await expect(createAgentSessionFromResourceLoader(resourceLoader, uiProvider)).rejects.toThrow(
 			"Failed to load resources",
 		);
-	});
-
-	test("passes uiProvider through to the session", async () => {
-		const sessionManager = createMockSessionManager();
-		const authStorage = createMockAuthStorage();
-		const environment = createMockEnvironment();
-		const uiProvider = createMockUIProvider();
-
-		const resourceLoader: ResourceLoader = {
-			getResources: vi.fn(async () => ({
-				sessionManager,
-				authStorage,
-				environment,
-				systemPrompt: "Test prompt",
-			})),
-		};
-
-		const result = await createAgentSessionFromResourceLoader(resourceLoader, uiProvider);
-
-		// Verify the uiProvider on the created session matches what we passed
-		expect(result.session.uiProvider).toBe(uiProvider);
-
-		// Verify it is the actual mock (not a NoOp default)
-		expect(result.session.uiProvider).toBe(uiProvider);
-		expect(result.session.uiProvider.notify).toBeDefined();
 	});
 });

--- a/packages/otter-agent/src/session/agent-session-from-resource-loader.test.ts
+++ b/packages/otter-agent/src/session/agent-session-from-resource-loader.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test, vi } from "vitest";
+import type { ResourceLoader } from "../interfaces/resource-loader.js";
+import type { SessionManager } from "../interfaces/session-manager.js";
+import type { UIProvider } from "../interfaces/ui-provider.js";
+import { createAgentSessionFromResourceLoader } from "./agent-session.js";
+
+// ─── Test Helpers ─────────────────────────────────────────────────────
+
+function createMockSessionManager(): SessionManager {
+	let entryCounter = 0;
+	return {
+		appendMessage: vi.fn(() => String(++entryCounter)),
+		buildSessionContext: vi.fn(() => ({
+			messages: [],
+			thinkingLevel: "off" as const,
+			model: null,
+		})),
+		compact: vi.fn(() => String(++entryCounter)),
+		appendCustomEntry: vi.fn(() => String(++entryCounter)),
+		appendCustomMessageEntry: vi.fn(() => String(++entryCounter)),
+		appendModelChange: vi.fn(() => String(++entryCounter)),
+		appendThinkingLevelChange: vi.fn(() => String(++entryCounter)),
+		appendLabel: vi.fn(() => String(++entryCounter)),
+	};
+}
+
+function createMockAuthStorage() {
+	return {
+		getApiKey: vi.fn(async () => "test-api-key"),
+	};
+}
+
+function createMockEnvironment() {
+	return {
+		getSystemMessageAppend: () => undefined,
+		getTools: () => [],
+	};
+}
+
+function createMockUIProvider(): UIProvider {
+	return {
+		dialog: vi.fn(async () => {}),
+		confirm: vi.fn(async () => true),
+		input: vi.fn(async () => undefined),
+		select: vi.fn(async () => undefined),
+		notify: vi.fn(),
+	};
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("createAgentSessionFromResourceLoader", () => {
+	test("creates a session with resources from the loader and the provided UIProvider", async () => {
+		const sessionManager = createMockSessionManager();
+		const authStorage = createMockAuthStorage();
+		const environment = createMockEnvironment();
+		const uiProvider = createMockUIProvider();
+
+		const resourceLoader: ResourceLoader = {
+			getResources: vi.fn(async () => ({
+				sessionManager,
+				authStorage,
+				environment,
+				systemPrompt: "You are a test agent.",
+			})),
+		};
+
+		const result = await createAgentSessionFromResourceLoader(resourceLoader, uiProvider);
+
+		expect(result.session).toBeDefined();
+		expect(result.session.uiProvider).toBe(uiProvider);
+		expect(resourceLoader.getResources).toHaveBeenCalledOnce();
+	});
+
+	test("propagates errors from getResources()", async () => {
+		const uiProvider = createMockUIProvider();
+
+		const resourceLoader: ResourceLoader = {
+			getResources: vi.fn(async () => {
+				throw new Error("Failed to load resources");
+			}),
+		};
+
+		await expect(createAgentSessionFromResourceLoader(resourceLoader, uiProvider)).rejects.toThrow(
+			"Failed to load resources",
+		);
+	});
+
+	test("passes uiProvider through to the session", async () => {
+		const sessionManager = createMockSessionManager();
+		const authStorage = createMockAuthStorage();
+		const environment = createMockEnvironment();
+		const uiProvider = createMockUIProvider();
+
+		const resourceLoader: ResourceLoader = {
+			getResources: vi.fn(async () => ({
+				sessionManager,
+				authStorage,
+				environment,
+				systemPrompt: "Test prompt",
+			})),
+		};
+
+		const result = await createAgentSessionFromResourceLoader(resourceLoader, uiProvider);
+
+		// Verify the uiProvider on the created session matches what we passed
+		expect(result.session.uiProvider).toBe(uiProvider);
+
+		// Verify it is the actual mock (not a NoOp default)
+		expect(result.session.uiProvider).toBe(uiProvider);
+		expect(result.session.uiProvider.notify).toBeDefined();
+	});
+});

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -17,6 +17,7 @@ import type { ExtensionRunnerActions } from "../extension-core/extension-runner.
 import type { Extension } from "../extension-core/extension.js";
 import type { AgentEnvironment } from "../interfaces/agent-environment.js";
 import type { AuthStorage } from "../interfaces/auth-storage.js";
+import type { ResourceLoader } from "../interfaces/resource-loader.js";
 import type { EntryId, SessionManager } from "../interfaces/session-manager.js";
 import { isSkillSupportedAgentEnvironment } from "../interfaces/skill-supported-agent-environment.js";
 import type { ToolDefinition } from "../interfaces/tool-definition.js";
@@ -109,6 +110,21 @@ export async function createAgentSession(
 		messages: sessionContext.messages,
 	});
 	return { session };
+}
+
+/**
+ * Async factory that creates an AgentSession from a ResourceLoader and UIProvider.
+ *
+ * Delegates resource loading to the ResourceLoader, then passes the
+ * assembled options (including the caller-supplied UIProvider) to
+ * {@link createAgentSession}.
+ */
+export async function createAgentSessionFromResourceLoader(
+	resourceLoader: ResourceLoader,
+	uiProvider: UIProvider,
+): Promise<CreateAgentSessionResult> {
+	const resources = await resourceLoader.getResources();
+	return createAgentSession({ ...resources, uiProvider });
 }
 
 /** Options for creating an AgentSession. */

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -17,6 +17,7 @@ import type { ExtensionRunnerActions } from "../extension-core/extension-runner.
 import type { Extension } from "../extension-core/extension.js";
 import type { AgentEnvironment } from "../interfaces/agent-environment.js";
 import type { AuthStorage } from "../interfaces/auth-storage.js";
+import type { ResourceLoader } from "../interfaces/resource-loader.js";
 import type { EntryId, SessionManager } from "../interfaces/session-manager.js";
 import { isSkillSupportedAgentEnvironment } from "../interfaces/skill-supported-agent-environment.js";
 import type { ToolDefinition } from "../interfaces/tool-definition.js";
@@ -24,7 +25,6 @@ import type { UIProvider } from "../interfaces/ui-provider.js";
 import { createNoOpUIProvider } from "../ui-providers/no-op-ui-provider.js";
 import { convertToLlm } from "./messages.js";
 import { ModelRegistry } from "./model-registry.js";
-import type { ResourceLoader } from "./resource-loader.js";
 import { buildSkillInvocationXml } from "./skill-invocation.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { wrapToolDefinition } from "./tool-wrapper.js";

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -17,7 +17,6 @@ import type { ExtensionRunnerActions } from "../extension-core/extension-runner.
 import type { Extension } from "../extension-core/extension.js";
 import type { AgentEnvironment } from "../interfaces/agent-environment.js";
 import type { AuthStorage } from "../interfaces/auth-storage.js";
-import type { ResourceLoader } from "../interfaces/resource-loader.js";
 import type { EntryId, SessionManager } from "../interfaces/session-manager.js";
 import { isSkillSupportedAgentEnvironment } from "../interfaces/skill-supported-agent-environment.js";
 import type { ToolDefinition } from "../interfaces/tool-definition.js";
@@ -25,6 +24,7 @@ import type { UIProvider } from "../interfaces/ui-provider.js";
 import { createNoOpUIProvider } from "../ui-providers/no-op-ui-provider.js";
 import { convertToLlm } from "./messages.js";
 import { ModelRegistry } from "./model-registry.js";
+import type { ResourceLoader } from "./resource-loader.js";
 import { buildSkillInvocationXml } from "./skill-invocation.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { wrapToolDefinition } from "./tool-wrapper.js";

--- a/packages/otter-agent/src/session/index.ts
+++ b/packages/otter-agent/src/session/index.ts
@@ -9,7 +9,6 @@ export type {
 	CreateAgentSessionOptions,
 	CreateAgentSessionResult,
 } from "./agent-session.js";
-export type { ResourceLoader } from "./resource-loader.js";
 export { convertToLlm, createCompactionSummaryMessage, createCustomMessage } from "./messages.js";
 export type { CompactionSummaryMessage, CustomMessage } from "./messages.js";
 export { ModelRegistry } from "./model-registry.js";

--- a/packages/otter-agent/src/session/index.ts
+++ b/packages/otter-agent/src/session/index.ts
@@ -1,4 +1,8 @@
-export { AgentSession, createAgentSession } from "./agent-session.js";
+export {
+	AgentSession,
+	createAgentSession,
+	createAgentSessionFromResourceLoader,
+} from "./agent-session.js";
 export type {
 	AgentSessionEvent,
 	AgentSessionOptions,

--- a/packages/otter-agent/src/session/index.ts
+++ b/packages/otter-agent/src/session/index.ts
@@ -9,6 +9,7 @@ export type {
 	CreateAgentSessionOptions,
 	CreateAgentSessionResult,
 } from "./agent-session.js";
+export type { ResourceLoader } from "./resource-loader.js";
 export { convertToLlm, createCompactionSummaryMessage, createCustomMessage } from "./messages.js";
 export type { CompactionSummaryMessage, CustomMessage } from "./messages.js";
 export { ModelRegistry } from "./model-registry.js";

--- a/packages/otter-agent/src/session/resource-loader.ts
+++ b/packages/otter-agent/src/session/resource-loader.ts
@@ -1,4 +1,4 @@
-import type { CreateAgentSessionOptions } from "../session/agent-session.js";
+import type { CreateAgentSessionOptions } from "./agent-session.js";
 
 /**
  * Provides the resources needed to create an agent session.


### PR DESCRIPTION
## Summary

Adds a new `ResourceLoader` interface and a `createAgentSessionFromResourceLoader()` convenience factory function. Closes #99.

## What Changed

### New interface: `ResourceLoader` (`src/interfaces/resource-loader.ts`)

A single async method `getResources()` that returns `Promise<Omit<CreateAgentSessionOptions, "uiProvider">>`. Implementations provide all session resources (session manager, auth storage, environment, system prompt, optional model/thinking level/extensions/agent options); the caller supplies the `uiProvider` separately.

### New factory: `createAgentSessionFromResourceLoader()` (`src/session/agent-session.ts`)

Thin async wrapper that calls `resourceLoader.getResources()`, merges with the caller-supplied `uiProvider`, and delegates to `createAgentSession()`.

### Tests

3 unit tests covering:
- Valid resources + UIProvider passthrough
- Optional field forwarding (thinkingLevel)
- Error propagation from `getResources()`

## Design Decisions

- **`ResourceLoader` lives in `src/interfaces/`** alongside all other interfaces. A type-only circular dependency with `session/agent-session.ts` is accepted as inherent and harmless.
- **No `ComponentTemplate` alias** — `ResourceLoader` is a different concept from the component template pattern.
- **No built-in implementations** — consumers provide their own.
- **`getResources()` is async** to support implementations that load resources from files, network, etc.

## Commits

1. `9c053ab` — Initial implementation
2. `10ccb40` — Address first code review findings
3. `7f0f1f9` — Move interface back to `interfaces/`, fix export ordering, improve test assertions

## Checks

- ✅ Build (TypeScript)
- ✅ Tests (599/599)
- ✅ Lint (Biome)
- ✅ Format (Biome)
- ✅ Independent code review approved