### PR TITLE
feat: add @otter-agent/environment-registry package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1808,6 +1808,10 @@
 			"resolved": "packages/otter-agent",
 			"link": true
 		},
+		"node_modules/@otter-agent/environment-registry": {
+			"resolved": "packages/environment-registry",
+			"link": true
+		},
 		"node_modules/@otter-agent/extension-registry": {
 			"resolved": "packages/extension-registry",
 			"link": true
@@ -6044,6 +6048,14 @@
 			"license": "ISC",
 			"peerDependencies": {
 				"zod": "^3.25.28 || ^4"
+			}
+		},
+		"packages/environment-registry": {
+			"name": "@otter-agent/environment-registry",
+			"version": "0.0.1",
+			"dependencies": {
+				"@otter-agent/core": "*",
+				"@sinclair/typebox": "^0.34.0"
 			}
 		},
 		"packages/extension-registry": {

--- a/packages/environment-registry/LICENSE
+++ b/packages/environment-registry/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 BowerJames
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/environment-registry/package.json
+++ b/packages/environment-registry/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "@otter-agent/environment-registry",
+	"version": "0.0.1",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc",
+		"test": "vitest run",
+		"dev": "tsc --watch"
+	},
+	"dependencies": {
+		"@otter-agent/core": "*",
+		"@sinclair/typebox": "^0.34.0"
+	}
+}

--- a/packages/environment-registry/src/built-ins/index.ts
+++ b/packages/environment-registry/src/built-ins/index.ts
@@ -1,0 +1,1 @@
+export { JustBashTemplate } from "./just-bash/index.js";

--- a/packages/environment-registry/src/built-ins/just-bash/index.ts
+++ b/packages/environment-registry/src/built-ins/just-bash/index.ts
@@ -1,0 +1,1 @@
+export { JustBashTemplate } from "./just-bash.js";

--- a/packages/environment-registry/src/built-ins/just-bash/just-bash.ts
+++ b/packages/environment-registry/src/built-ins/just-bash/just-bash.ts
@@ -1,0 +1,3 @@
+import { JustBashAgentEnvironmentTemplate } from "@otter-agent/core";
+
+export { JustBashAgentEnvironmentTemplate as JustBashTemplate };

--- a/packages/environment-registry/src/convenience.test.ts
+++ b/packages/environment-registry/src/convenience.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for convenience functions (buildEnvironment, isRegistered, getRegisteredNames).
+ *
+ * These test the public API directly rather than relying on indirect coverage
+ * via the default-registry tests. This catches regressions if convenience.ts
+ * is accidentally changed to delegate to a different registry instance.
+ */
+import { describe, expect, it } from "vitest";
+import { buildEnvironment, getRegisteredNames, isRegistered } from "./convenience.js";
+
+describe("convenience functions", () => {
+	describe("isRegistered", () => {
+		it("returns true for a built-in template", () => {
+			expect(isRegistered("just-bash")).toBe(true);
+		});
+
+		it("returns false for an unknown name", () => {
+			expect(isRegistered("nonexistent")).toBe(false);
+		});
+	});
+
+	describe("getRegisteredNames", () => {
+		it("returns an array containing all built-in names", () => {
+			const names = getRegisteredNames();
+			expect(Array.isArray(names)).toBe(true);
+			expect(names).toContain("just-bash");
+		});
+
+		it("returns a copy (mutations do not affect the registry)", () => {
+			const names = getRegisteredNames();
+			names.push("injected");
+			expect(getRegisteredNames()).not.toContain("injected");
+		});
+	});
+
+	describe("buildEnvironment", () => {
+		it("builds a known template with config", () => {
+			const env = buildEnvironment("just-bash", { cwd: "/workspace" });
+			expect(env).toBeDefined();
+			expect(env.getTools().length).toBeGreaterThan(0);
+		});
+
+		it("builds a known template without config", () => {
+			const env = buildEnvironment("just-bash");
+			expect(env).toBeDefined();
+			expect(env.getTools().length).toBeGreaterThan(0);
+		});
+
+		it("throws for an unknown name", () => {
+			expect(() => buildEnvironment("nonexistent")).toThrow(
+				'No environment template registered under "nonexistent"',
+			);
+		});
+
+		it("throws on invalid config", () => {
+			expect(() => buildEnvironment("just-bash", { cwd: 42 as unknown as string })).toThrow(
+				"Component config validation failed",
+			);
+		});
+	});
+});

--- a/packages/environment-registry/src/convenience.ts
+++ b/packages/environment-registry/src/convenience.ts
@@ -1,0 +1,44 @@
+import type { AgentEnvironment } from "@otter-agent/core";
+import { defaultRegistry } from "./default-registry.js";
+
+/**
+ * Build an environment from the default registry.
+ *
+ * @param name - The registered template name (e.g. "just-bash").
+ * @param config - Optional user-provided config. Deep-merged with the
+ *   template's defaults before validation.
+ * @returns A built AgentEnvironment ready for use with AgentSession.
+ * @throws {EnvironmentRegistryError} If no template is registered under the given name.
+ * @throws {ComponentConfigValidationError} If config validation fails.
+ *
+ * @example
+ * ```ts
+ * import { buildEnvironment } from "@otter-agent/environment-registry";
+ *
+ * const environment = buildEnvironment("just-bash", {
+ *   cwd: "/workspace",
+ * });
+ * ```
+ */
+export function buildEnvironment(name: string, config?: Record<string, unknown>): AgentEnvironment {
+	return defaultRegistry.build(name, config);
+}
+
+/**
+ * Check if a name is registered in the default registry.
+ *
+ * @param name - The template name to check.
+ * @returns `true` if registered.
+ */
+export function isRegistered(name: string): boolean {
+	return defaultRegistry.has(name);
+}
+
+/**
+ * List all registered names in the default registry.
+ *
+ * @returns Array of registered names in insertion order.
+ */
+export function getRegisteredNames(): string[] {
+	return defaultRegistry.getRegisteredNames();
+}

--- a/packages/environment-registry/src/default-registry.test.ts
+++ b/packages/environment-registry/src/default-registry.test.ts
@@ -1,0 +1,48 @@
+import {
+	JustBashAgentEnvironmentOptionsSchema,
+	JustBashAgentEnvironmentTemplate,
+} from "@otter-agent/core";
+/**
+ * Tests for the default registry.
+ */
+import { describe, expect, it } from "vitest";
+import { defaultRegistry } from "./default-registry.js";
+
+describe("defaultRegistry", () => {
+	it("has the just-bash built-in registered", () => {
+		expect(defaultRegistry.has("just-bash")).toBe(true);
+	});
+
+	it("returns the correct template for just-bash", () => {
+		const template = defaultRegistry.get("just-bash");
+		expect(template).toBe(JustBashAgentEnvironmentTemplate);
+	});
+
+	it("just-bash template has the correct schema", () => {
+		const template = defaultRegistry.get("just-bash");
+		expect(template?.configSchema()).toBe(JustBashAgentEnvironmentOptionsSchema);
+	});
+
+	it("builds a working just-bash environment", () => {
+		const env = defaultRegistry.build("just-bash", {
+			cwd: "/workspace",
+		});
+		expect(env).toBeDefined();
+		expect(env.getTools().length).toBeGreaterThan(0);
+	});
+
+	it("does not have unregistered names", () => {
+		expect(defaultRegistry.has("nonexistent")).toBe(false);
+	});
+
+	it("throws for unknown build", () => {
+		expect(() => defaultRegistry.build("nonexistent")).toThrow(
+			'No environment template registered under "nonexistent"',
+		);
+	});
+
+	it("lists registered names", () => {
+		const names = defaultRegistry.getRegisteredNames();
+		expect(names).toContain("just-bash");
+	});
+});

--- a/packages/environment-registry/src/default-registry.ts
+++ b/packages/environment-registry/src/default-registry.ts
@@ -1,0 +1,19 @@
+import { JustBashTemplate } from "./built-ins/index.js";
+import { EnvironmentRegistry } from "./registry.js";
+
+/**
+ * The default environment registry, pre-populated with all built-in templates.
+ *
+ * @example
+ * ```ts
+ * import { defaultRegistry } from "@otter-agent/environment-registry";
+ *
+ * const environment = defaultRegistry.build("just-bash", {
+ *   cwd: "/workspace",
+ * });
+ * ```
+ */
+export const defaultRegistry = new EnvironmentRegistry();
+
+// Register all built-in templates
+defaultRegistry.register("just-bash", JustBashTemplate);

--- a/packages/environment-registry/src/index.ts
+++ b/packages/environment-registry/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @otter-agent/environment-registry
+ *
+ * A dynamic registry of named environment templates with a default
+ * pre-populated singleton and convenience functions.
+ */
+
+// Registry
+export { EnvironmentRegistry, EnvironmentRegistryError } from "./registry.js";
+
+// Default registry (pre-populated singleton)
+export { defaultRegistry } from "./default-registry.js";
+
+// Convenience functions (delegate to the default registry)
+export { buildEnvironment, getRegisteredNames, isRegistered } from "./convenience.js";
+
+// Built-in templates (also importable individually)
+export { JustBashTemplate } from "./built-ins/index.js";
+
+// Re-export core types consumers need
+export type { AgentEnvironment, ComponentTemplate } from "@otter-agent/core";
+export {
+	ComponentConfigValidationError,
+	validateComponentConfig,
+	validateComponentConfigOnly,
+} from "@otter-agent/core";

--- a/packages/environment-registry/src/registry.test.ts
+++ b/packages/environment-registry/src/registry.test.ts
@@ -1,0 +1,149 @@
+import { validateComponentConfig } from "@otter-agent/core";
+import { Type } from "@sinclair/typebox";
+import { describe, expect, it } from "vitest";
+import { EnvironmentRegistry, EnvironmentRegistryError } from "./registry.js";
+
+// Minimal test template
+const TestConfigSchema = Type.Object({
+	enabled: Type.Boolean({ default: true }),
+	label: Type.String({ default: "test" }),
+});
+
+type TestConfig = { enabled: boolean; label: string };
+
+const testTemplate = {
+	configSchema: () => TestConfigSchema,
+	defaultConfig: (): TestConfig => ({ enabled: true, label: "test" }),
+	build: (config: TestConfig) => {
+		return {
+			getSystemMessageAppend: () => `enabled=${config.enabled} label=${config.label}`,
+			getTools: () => [],
+		};
+	},
+};
+
+describe("EnvironmentRegistry", () => {
+	describe("register", () => {
+		it("registers a template under a name", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("test", testTemplate);
+			expect(registry.has("test")).toBe(true);
+		});
+
+		it("throws on duplicate name", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("test", testTemplate);
+			expect(() => registry.register("test", testTemplate)).toThrow(EnvironmentRegistryError);
+			expect(() => registry.register("test", testTemplate)).toThrow(
+				'template "test" is already registered',
+			);
+		});
+
+		it("allows different names", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("a", testTemplate);
+			registry.register("b", testTemplate);
+			expect(registry.has("a")).toBe(true);
+			expect(registry.has("b")).toBe(true);
+		});
+	});
+
+	describe("get", () => {
+		it("returns the registered template", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("test", testTemplate);
+			expect(registry.get("test")).toBe(testTemplate);
+		});
+
+		it("returns undefined for unknown name", () => {
+			const registry = new EnvironmentRegistry();
+			expect(registry.get("unknown")).toBeUndefined();
+		});
+	});
+
+	describe("has", () => {
+		it("returns true for registered name", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("test", testTemplate);
+			expect(registry.has("test")).toBe(true);
+		});
+
+		it("returns false for unknown name", () => {
+			const registry = new EnvironmentRegistry();
+			expect(registry.has("unknown")).toBe(false);
+		});
+
+		it("returns false for empty registry", () => {
+			const registry = new EnvironmentRegistry();
+			expect(registry.has("anything")).toBe(false);
+		});
+	});
+
+	describe("getRegisteredNames", () => {
+		it("returns empty array for empty registry", () => {
+			const registry = new EnvironmentRegistry();
+			expect(registry.getRegisteredNames()).toEqual([]);
+		});
+
+		it("returns all registered names in insertion order", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("first", testTemplate);
+			registry.register("second", testTemplate);
+			registry.register("third", testTemplate);
+			expect(registry.getRegisteredNames()).toEqual(["first", "second", "third"]);
+		});
+	});
+
+	describe("build", () => {
+		it("throws for unknown name", () => {
+			const registry = new EnvironmentRegistry();
+			expect(() => registry.build("unknown")).toThrow(EnvironmentRegistryError);
+			expect(() => registry.build("unknown")).toThrow(
+				'No environment template registered under "unknown"',
+			);
+		});
+
+		it("lists registered names in error message", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("known", testTemplate);
+			expect(() => registry.build("unknown")).toThrow(/Registered: known/);
+		});
+
+		it("builds with defaults when no config provided", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("test", testTemplate);
+			const env = registry.build("test");
+			expect(env).toBeDefined();
+			expect(env.getSystemMessageAppend()).toBe("enabled=true label=test");
+		});
+
+		it("builds with merged config", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("test", testTemplate);
+			const env = registry.build("test", { label: "custom" });
+			expect(env).toBeDefined();
+			expect(env.getSystemMessageAppend()).toBe("enabled=true label=custom");
+		});
+
+		it("throws on invalid config", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("test", testTemplate);
+			// Pass a value that violates the schema (enabled should be boolean)
+			expect(() =>
+				registry.build("test", { enabled: "not-a-boolean" as unknown as boolean }),
+			).toThrow("Component config validation failed");
+		});
+
+		it("delegates to validateComponentConfig from core", () => {
+			const registry = new EnvironmentRegistry();
+			registry.register("test", testTemplate);
+			const config = { label: "delegated" };
+			// Build via registry
+			const registryResult = registry.build("test", config);
+			// Build via core directly
+			const coreResult = validateComponentConfig(testTemplate, config);
+			// Both should produce environments
+			expect(registryResult.getSystemMessageAppend()).toBe(coreResult.getSystemMessageAppend());
+		});
+	});
+});

--- a/packages/environment-registry/src/registry.ts
+++ b/packages/environment-registry/src/registry.ts
@@ -1,0 +1,106 @@
+/**
+ * EnvironmentRegistry — a dynamic registry of named environment templates.
+ *
+ * Provides methods to register, look up, and build environments by name.
+ * A default pre-populated singleton is available via {@link defaultRegistry}.
+ */
+import { validateComponentConfig } from "@otter-agent/core";
+import type { ComponentTemplate } from "@otter-agent/core";
+import type { AgentEnvironment } from "@otter-agent/core";
+import type { TSchema } from "@sinclair/typebox";
+
+/**
+ * Error thrown when attempting to register a template under a name
+ * that is already in use.
+ */
+export class EnvironmentRegistryError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EnvironmentRegistryError";
+	}
+}
+
+/**
+ * A dynamic registry of named environment templates.
+ *
+ * Templates are registered with a unique string name and can be built
+ * into concrete AgentEnvironment instances with validated config.
+ *
+ * @example
+ * ```ts
+ * const registry = new EnvironmentRegistry();
+ * registry.register("my-env", myTemplate);
+ *
+ * const environment = registry.build("my-env", { someOption: true });
+ * ```
+ */
+export class EnvironmentRegistry {
+	private readonly _templates = new Map<string, ComponentTemplate<TSchema, AgentEnvironment>>();
+
+	/**
+	 * Register a template under the given name.
+	 *
+	 * @param name - Unique name for the template. Must not already be registered.
+	 * @param template - The environment template to register.
+	 * @throws {EnvironmentRegistryError} If a template with the same name is already registered.
+	 */
+	register(name: string, template: ComponentTemplate<TSchema, AgentEnvironment>): void {
+		if (this._templates.has(name)) {
+			throw new EnvironmentRegistryError(`Environment template "${name}" is already registered.`);
+		}
+		this._templates.set(name, template);
+	}
+
+	/**
+	 * Get a registered template by name.
+	 *
+	 * @param name - The registered template name.
+	 * @returns The template, or `undefined` if not found.
+	 */
+	get(name: string): ComponentTemplate<TSchema, AgentEnvironment> | undefined {
+		return this._templates.get(name);
+	}
+
+	/**
+	 * Check if a template is registered under the given name.
+	 *
+	 * @param name - The template name to check.
+	 * @returns `true` if a template is registered with this name.
+	 */
+	has(name: string): boolean {
+		return this._templates.has(name);
+	}
+
+	/**
+	 * List all registered template names.
+	 *
+	 * @returns Array of registered names in insertion order.
+	 */
+	getRegisteredNames(): string[] {
+		return [...this._templates.keys()];
+	}
+
+	/**
+	 * Build an environment by name with optional config.
+	 *
+	 * Delegates to {@link validateComponentConfig} from `@otter-agent/core`
+	 * for schema validation, default merging, and environment building.
+	 *
+	 * @param name - The registered template name.
+	 * @param config - Optional user-provided config. Deep-merged with the
+	 *   template's defaults before validation.
+	 * @returns A built AgentEnvironment ready for use with AgentSession.
+	 * @throws {EnvironmentRegistryError} If no template is registered under the given name.
+	 * @throws {ComponentConfigValidationError} If config validation fails.
+	 */
+	build(name: string, config?: Record<string, unknown>): AgentEnvironment {
+		const template = this._templates.get(name);
+		if (!template) {
+			throw new EnvironmentRegistryError(
+				`No environment template registered under "${name}". ` +
+					`Registered: ${this.getRegisteredNames().join(", ") || "(none)"}`,
+			);
+		}
+		return validateComponentConfig(template, config);
+	}
+}

--- a/packages/environment-registry/tsconfig.json
+++ b/packages/environment-registry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Implements #102 — a named registry of `AgentEnvironment` templates, mirroring the existing `@otter-agent/extension-registry` pattern.

### What's included

- **`EnvironmentRegistry`** class with `register()`, `get()`, `has()`, `getRegisteredNames()`, `build()`
- **`EnvironmentRegistryError`** for duplicate registration and missing template errors
- **`defaultRegistry`** singleton pre-populated with the `"just-bash"` template
- **Convenience functions:** `buildEnvironment()`, `isRegistered()`, `getRegisteredNames()`
- **`JustBashTemplate`** re-exporting `JustBashAgentEnvironmentTemplate` from `@otter-agent/core`
- Re-exports of core types (`AgentEnvironment`, `ComponentTemplate`) and utils (`validateComponentConfig`, `ComponentConfigValidationError`)

### Verification

- `npm run build` ✅
- `npm test` ✅ — 630/630 tests pass (31 new)
- `npm run lint` ✅

### Files changed (14)

| File | Purpose |
|---|---|
| `package.json` | Package manifest |
| `tsconfig.json` | TypeScript config |
| `LICENSE` | MIT license |
| `src/registry.ts` | `EnvironmentRegistry` class |
| `src/registry.test.ts` | 16 tests |
| `src/built-ins/just-bash/just-bash.ts` | Re-export `JustBashTemplate` |
| `src/built-ins/just-bash/index.ts` | Barrel |
| `src/built-ins/index.ts` | Barrel |
| `src/default-registry.ts` | Default singleton |
| `src/default-registry.test.ts` | 7 tests |
| `src/convenience.ts` | Convenience functions |
| `src/convenience.test.ts` | 8 tests |
| `src/index.ts` | Package barrel export |

Closes #102