### PR TITLE
feat: add MaybePromise<T> to allow sync or async interface methods

### DIFF
--- a/packages/otter-agent/src/interfaces/agent-environment.ts
+++ b/packages/otter-agent/src/interfaces/agent-environment.ts
@@ -1,3 +1,4 @@
+import type { MaybePromise } from "../utils/maybe-promise.js";
 import type { ToolDefinition } from "./tool-definition.js";
 
 /**
@@ -29,7 +30,7 @@ export interface AgentEnvironment {
 	 * @returns A string to append to the system prompt, or `undefined` if
 	 * the environment has nothing to add.
 	 */
-	getSystemMessageAppend(): string | undefined;
+	getSystemMessageAppend(): MaybePromise<string | undefined>;
 
 	/**
 	 * Tools the environment exposes to the agent for interacting with it.
@@ -41,5 +42,5 @@ export interface AgentEnvironment {
 	 * @returns An array of tool definitions, or an empty array if the
 	 * environment provides no tools.
 	 */
-	getTools(): ToolDefinition[];
+	getTools(): MaybePromise<ToolDefinition[]>;
 }

--- a/packages/otter-agent/src/interfaces/auth-storage.ts
+++ b/packages/otter-agent/src/interfaces/auth-storage.ts
@@ -1,3 +1,5 @@
+import type { MaybePromise } from "../utils/maybe-promise.js";
+
 /**
  * Minimal interface for credential retrieval.
  *
@@ -18,5 +20,5 @@ export interface AuthStorage {
 	 * @param provider - The LLM provider identifier (e.g., "anthropic", "openai").
 	 * @returns The API key string, or `undefined` if not available.
 	 */
-	getApiKey(provider: string): Promise<string | undefined>;
+	getApiKey(provider: string): MaybePromise<string | undefined>;
 }

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -1,3 +1,4 @@
+export type { MaybePromise } from "../utils/maybe-promise.js";
 export type { AgentEnvironment } from "./agent-environment.js";
 export type { AuthStorage } from "./auth-storage.js";
 export type {

--- a/packages/otter-agent/src/interfaces/index.ts
+++ b/packages/otter-agent/src/interfaces/index.ts
@@ -1,4 +1,3 @@
-export type { MaybePromise } from "../utils/maybe-promise.js";
 export type { AgentEnvironment } from "./agent-environment.js";
 export type { AuthStorage } from "./auth-storage.js";
 export type {
@@ -14,6 +13,7 @@ export type {
 	ReadonlySessionManager,
 	EntryId,
 } from "./session-manager.js";
+export type { MaybePromise } from "../utils/maybe-promise.js";
 export type { ResourceLoader } from "./resource-loader.js";
 export type { SkillDefinition } from "./skill-definition.js";
 export type { SkillSupportedAgentEnvironment } from "./skill-supported-agent-environment.js";

--- a/packages/otter-agent/src/interfaces/resource-loader.ts
+++ b/packages/otter-agent/src/interfaces/resource-loader.ts
@@ -1,4 +1,5 @@
 import type { CreateAgentSessionOptions } from "../session/agent-session.js";
+import type { MaybePromise } from "../utils/maybe-promise.js";
 
 /**
  * Provides the resources needed to create an agent session.
@@ -14,5 +15,5 @@ export interface ResourceLoader {
 	 * @returns An object satisfying {@link CreateAgentSessionOptions}
 	 *          minus {@link UIProvider}.
 	 */
-	getResources(): Promise<Omit<CreateAgentSessionOptions, "uiProvider">>;
+	getResources(): MaybePromise<Omit<CreateAgentSessionOptions, "uiProvider">>;
 }

--- a/packages/otter-agent/src/interfaces/session-manager.ts
+++ b/packages/otter-agent/src/interfaces/session-manager.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
+import type { MaybePromise } from "../utils/maybe-promise.js";
 
 /**
  * A unique identifier for a session entry.
@@ -74,7 +75,7 @@ export interface SessionManager {
 	 * @param message - The agent message to persist.
 	 * @returns The unique ID of the created entry.
 	 */
-	appendMessage(message: AgentMessage): Promise<EntryId>;
+	appendMessage(message: AgentMessage): MaybePromise<EntryId>;
 
 	/**
 	 * Build the session context for the LLM.
@@ -91,7 +92,7 @@ export interface SessionManager {
 	 *
 	 * @returns The session context including messages, thinking level, and model.
 	 */
-	buildSessionContext(): Promise<SessionContext>;
+	buildSessionContext(): MaybePromise<SessionContext>;
 
 	/**
 	 * Record a compaction event. When `buildSessionContext()` is called,
@@ -117,7 +118,7 @@ export interface SessionManager {
 		firstKeptEntryId?: EntryId,
 		tokensBefore?: number,
 		details?: unknown,
-	): Promise<EntryId>;
+	): MaybePromise<EntryId>;
 
 	/**
 	 * Persist extension state that is NOT included in LLM context.
@@ -130,7 +131,7 @@ export interface SessionManager {
 	 * @param data - Optional extension-specific data to persist.
 	 * @returns The unique ID of the created entry.
 	 */
-	appendCustomEntry(customType: string, data?: unknown): Promise<EntryId>;
+	appendCustomEntry(customType: string, data?: unknown): MaybePromise<EntryId>;
 
 	/**
 	 * Persist an extension message that IS included in LLM context.
@@ -151,7 +152,7 @@ export interface SessionManager {
 		content: string | (TextContent | ImageContent)[],
 		display: boolean,
 		details?: unknown,
-	): Promise<EntryId>;
+	): MaybePromise<EntryId>;
 
 	/**
 	 * Record a model and thinking level change.
@@ -166,7 +167,7 @@ export interface SessionManager {
 	appendModelChange(
 		model: { provider: string; modelId: string },
 		thinkingLevel: string,
-	): Promise<EntryId>;
+	): MaybePromise<EntryId>;
 
 	/**
 	 * Record a thinking level change.
@@ -177,7 +178,7 @@ export interface SessionManager {
 	 * @param thinkingLevel - The new thinking level.
 	 * @returns The unique ID of the created entry.
 	 */
-	appendThinkingLevelChange(thinkingLevel: string): Promise<EntryId>;
+	appendThinkingLevelChange(thinkingLevel: string): MaybePromise<EntryId>;
 
 	/**
 	 * Attach a label/bookmark to a specific entry.
@@ -189,7 +190,7 @@ export interface SessionManager {
 	 * @param targetEntryId - The ID of the entry to label.
 	 * @returns The unique ID of the label entry.
 	 */
-	appendLabel(label: string, targetEntryId: EntryId): Promise<EntryId>;
+	appendLabel(label: string, targetEntryId: EntryId): MaybePromise<EntryId>;
 
 	/**
 	 * Return all entries for this session in append order.
@@ -204,7 +205,7 @@ export interface SessionManager {
 	 * @returns A read-only snapshot of all entries. Callers must not mutate
 	 *   the returned array or its elements.
 	 */
-	getEntries(): Promise<Entry[]>;
+	getEntries(): MaybePromise<Entry[]>;
 }
 
 /**

--- a/packages/otter-agent/src/interfaces/ui-provider.ts
+++ b/packages/otter-agent/src/interfaces/ui-provider.ts
@@ -1,3 +1,5 @@
+import type { MaybePromise } from "../utils/maybe-promise.js";
+
 /**
  * Optional interface for extension-to-user interaction.
  *
@@ -15,7 +17,7 @@ export interface UIProvider {
 	 * @param title - Dialog title.
 	 * @param body - Dialog body text.
 	 */
-	dialog(title: string, body: string): Promise<void>;
+	dialog(title: string, body: string): MaybePromise<void>;
 
 	/**
 	 * Show a yes/no confirmation dialog.
@@ -24,7 +26,7 @@ export interface UIProvider {
 	 * @param body - Confirmation body text.
 	 * @returns `true` if the user confirmed, `false` otherwise.
 	 */
-	confirm(title: string, body: string): Promise<boolean>;
+	confirm(title: string, body: string): MaybePromise<boolean>;
 
 	/**
 	 * Prompt the user for free text input.
@@ -33,7 +35,7 @@ export interface UIProvider {
 	 * @param placeholder - Optional placeholder text.
 	 * @returns The entered text, or `undefined` if cancelled.
 	 */
-	input(title: string, placeholder?: string): Promise<string | undefined>;
+	input(title: string, placeholder?: string): MaybePromise<string | undefined>;
 
 	/**
 	 * Show a selection list for the user to pick from.
@@ -42,7 +44,7 @@ export interface UIProvider {
 	 * @param items - The items to choose from.
 	 * @returns The selected item, or `undefined` if cancelled.
 	 */
-	select<T>(title: string, items: T[]): Promise<T | undefined>;
+	select<T>(title: string, items: T[]): MaybePromise<T | undefined>;
 
 	/**
 	 * Show a transient notification to the user.
@@ -50,5 +52,5 @@ export interface UIProvider {
 	 * @param message - Notification message text.
 	 * @param type - Notification severity. Defaults to "info".
 	 */
-	notify(message: string, type?: "info" | "warning" | "error"): void;
+	notify(message: string, type?: "info" | "warning" | "error"): MaybePromise<void>;
 }

--- a/packages/otter-agent/src/rpc/rpc-handler.test.ts
+++ b/packages/otter-agent/src/rpc/rpc-handler.test.ts
@@ -44,6 +44,25 @@ function createMockEnvironment(): AgentEnvironment {
 	};
 }
 
+function createSessionOptions(overrides?: {
+	environment?: AgentEnvironment;
+	sessionManager?: SessionManager;
+	authStorage?: AuthStorage;
+	systemPrompt?: string;
+	uiProvider?: import("../interfaces/ui-provider.js").UIProvider;
+}) {
+	const environment = overrides?.environment ?? createMockEnvironment();
+	return {
+		sessionManager: overrides?.sessionManager ?? createMockSessionManager(),
+		authStorage: overrides?.authStorage ?? createMockAuthStorage(),
+		environment,
+		systemPrompt: overrides?.systemPrompt ?? "Test prompt",
+		environmentTools: environment.getTools(),
+		environmentAppend: environment.getSystemMessageAppend(),
+		...(overrides?.uiProvider !== undefined ? { uiProvider: overrides.uiProvider } : {}),
+	};
+}
+
 interface MockTransport extends RpcTransport {
 	sent: RpcOutboundMessage[];
 	messageHandler: ((message: RpcInboundMessage) => void) | undefined;
@@ -78,13 +97,7 @@ function createMockTransport(): MockTransport {
 function createTestSetup() {
 	const transport = createMockTransport();
 	const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
-	const session = new AgentSession({
-		sessionManager: createMockSessionManager(),
-		authStorage: createMockAuthStorage(),
-		environment: createMockEnvironment(),
-		systemPrompt: "Test prompt",
-		uiProvider,
-	});
+	const session = new AgentSession(createSessionOptions({ uiProvider }));
 	const handler = new RpcHandler({
 		session,
 		transport,
@@ -220,12 +233,7 @@ describe("RpcHandler", () => {
 		const resolveUIResponse = vi.fn((_response: ExtensionUIResponse) => {});
 		const rejectAllUI = vi.fn((_reason: string) => {});
 		const transport = createMockTransport();
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test",
-		});
+		const session = new AgentSession(createSessionOptions({ systemPrompt: "Test" }));
 
 		const handler = new RpcHandler({
 			session,
@@ -254,13 +262,7 @@ describe("RpcHandler", () => {
 		const resolveUIResponse = vi.fn((_response: ExtensionUIResponse) => {});
 		const transport = createMockTransport();
 		const { uiProvider } = createRpcUIProvider(transport);
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test",
-			uiProvider,
-		});
+		const session = new AgentSession(createSessionOptions({ systemPrompt: "Test", uiProvider }));
 
 		const handler = new RpcHandler({
 			session,
@@ -280,13 +282,7 @@ describe("RpcHandler", () => {
 		const onShutdown = vi.fn(() => {});
 		const transport = createMockTransport();
 		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test prompt",
-			uiProvider,
-		});
+		const session = new AgentSession(createSessionOptions({ uiProvider }));
 		const handler = new RpcHandler({
 			session,
 			transport,
@@ -358,13 +354,7 @@ describe("RpcHandler", () => {
 		const commandHandler = vi.fn(async () => {});
 		const transport = createMockTransport();
 		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test",
-			uiProvider,
-		});
+		const session = new AgentSession(createSessionOptions({ systemPrompt: "Test", uiProvider }));
 
 		await session.loadExtensions([
 			(api) => {
@@ -459,13 +449,7 @@ describe("RpcHandler graceful shutdown", () => {
 		const onShutdown = vi.fn(() => {});
 		const transport = createMockTransport();
 		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test prompt",
-			uiProvider,
-		});
+		const session = new AgentSession(createSessionOptions({ uiProvider }));
 		const handler = new RpcHandler({
 			session,
 			transport,
@@ -493,13 +477,7 @@ describe("RpcHandler graceful shutdown", () => {
 		const transport = createMockTransport();
 		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
 		const rejectAllSpy = vi.fn((_reason: string) => rejectAll(_reason));
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test prompt",
-			uiProvider,
-		});
+		const session = new AgentSession(createSessionOptions({ uiProvider }));
 
 		const handler = new RpcHandler({
 			session,
@@ -535,13 +513,7 @@ describe("RpcHandler graceful shutdown", () => {
 			origSend(message);
 		};
 		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test prompt",
-			uiProvider,
-		});
+		const session = new AgentSession(createSessionOptions({ uiProvider }));
 		const handler = new RpcHandler({
 			session,
 			transport,
@@ -561,13 +533,7 @@ describe("RpcHandler graceful shutdown", () => {
 		const onShutdown = vi.fn(() => {});
 		const transport = createMockTransport();
 		const { uiProvider, resolveResponse, rejectAll } = createRpcUIProvider(transport);
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test prompt",
-			uiProvider,
-		});
+		const session = new AgentSession(createSessionOptions({ uiProvider }));
 		const handler = new RpcHandler({
 			session,
 			transport,
@@ -593,12 +559,7 @@ describe("AgentSession slash command interception", () => {
 	test("executes registered extension command on /prefix", async () => {
 		const commandHandler = vi.fn(async () => {});
 
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test",
-		});
+		const session = new AgentSession(createSessionOptions({ systemPrompt: "Test" }));
 
 		// Load an extension that registers a command
 		await session.loadExtensions([
@@ -620,12 +581,7 @@ describe("AgentSession slash command interception", () => {
 	});
 
 	test("falls through to LLM for unknown /commands", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Test",
-		});
+		const session = new AgentSession(createSessionOptions({ systemPrompt: "Test" }));
 
 		// No extensions registered, so /unknown should fall through
 		// Since no model is set, this will error — but the point is it tries

--- a/packages/otter-agent/src/session/agent-session.test.ts
+++ b/packages/otter-agent/src/session/agent-session.test.ts
@@ -44,6 +44,35 @@ function createMockEnvironment(options?: {
 	};
 }
 
+function createSessionOptions(overrides?: {
+	environment?: AgentEnvironment;
+	systemPrompt?: string;
+	sessionManager?: SessionManager;
+	authStorage?: AuthStorage;
+	model?: Model<Api>;
+	thinkingLevel?: ThinkingLevel;
+	uiProvider?: import("../interfaces/ui-provider.js").UIProvider;
+	extensions?: Extension[];
+	messages?: AgentMessage[];
+	agentOptions?: Partial<import("@mariozechner/pi-agent-core").AgentOptions>;
+}) {
+	const environment = overrides?.environment ?? createMockEnvironment();
+	return {
+		sessionManager: overrides?.sessionManager ?? createMockSessionManager(),
+		authStorage: overrides?.authStorage ?? createMockAuthStorage(),
+		environment,
+		systemPrompt: overrides?.systemPrompt ?? "You are a helpful assistant.",
+		environmentTools: environment.getTools(),
+		environmentAppend: environment.getSystemMessageAppend(),
+		...(overrides?.model !== undefined ? { model: overrides.model } : {}),
+		...(overrides?.thinkingLevel !== undefined ? { thinkingLevel: overrides.thinkingLevel } : {}),
+		...(overrides?.uiProvider !== undefined ? { uiProvider: overrides.uiProvider } : {}),
+		...(overrides?.extensions !== undefined ? { extensions: overrides.extensions } : {}),
+		...(overrides?.messages !== undefined ? { messages: overrides.messages } : {}),
+		...(overrides?.agentOptions !== undefined ? { agentOptions: overrides.agentOptions } : {}),
+	};
+}
+
 function createTestTool(name: string): ToolDefinition {
 	return {
 		name,
@@ -65,12 +94,7 @@ function createTestTool(name: string): ToolDefinition {
 
 describe("AgentSession", () => {
 	test("constructs with minimal options", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "You are a helpful assistant.",
-		});
+		const session = new AgentSession(createSessionOptions());
 
 		expect(session.agent).toBeDefined();
 		expect(session.sessionManager).toBeDefined();
@@ -80,14 +104,14 @@ describe("AgentSession", () => {
 	});
 
 	test("appends environment system message", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment({
-				systemAppend: "You are in a Docker container.",
+		const session = new AgentSession(
+			createSessionOptions({
+				environment: createMockEnvironment({
+					systemAppend: "You are in a Docker container.",
+				}),
+				systemPrompt: "Base prompt.",
 			}),
-			systemPrompt: "Base prompt.",
-		});
+		);
 
 		expect(session.agent.state.systemPrompt).toContain("Base prompt.");
 		expect(session.agent.state.systemPrompt).toContain("You are in a Docker container.");
@@ -97,12 +121,9 @@ describe("AgentSession", () => {
 
 	test("registers environment tools", async () => {
 		const tool = createTestTool("env_tool");
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment({ tools: [tool] }),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(
+			createSessionOptions({ environment: createMockEnvironment({ tools: [tool] }) }),
+		);
 
 		expect(session.getActiveToolNames()).toContain("env_tool");
 		expect(session.agent.state.tools).toHaveLength(1);
@@ -113,12 +134,12 @@ describe("AgentSession", () => {
 
 	test("includes tool snippets and guidelines in system prompt", async () => {
 		const tool = createTestTool("my_tool");
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment({ tools: [tool] }),
-			systemPrompt: "Base.",
-		});
+		const session = new AgentSession(
+			createSessionOptions({
+				environment: createMockEnvironment({ tools: [tool] }),
+				systemPrompt: "Base.",
+			}),
+		);
 
 		const prompt = session.agent.state.systemPrompt;
 		expect(prompt).toContain("# Available Tools");
@@ -130,12 +151,7 @@ describe("AgentSession", () => {
 	});
 
 	test("registerTool adds a tool and updates the agent", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions());
 
 		expect(session.agent.state.tools).toHaveLength(0);
 
@@ -152,12 +168,9 @@ describe("AgentSession", () => {
 	test("setActiveToolsByName filters to valid tools", async () => {
 		const tool1 = createTestTool("tool_a");
 		const tool2 = createTestTool("tool_b");
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment({ tools: [tool1, tool2] }),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(
+			createSessionOptions({ environment: createMockEnvironment({ tools: [tool1, tool2] }) }),
+		);
 
 		expect(session.getActiveToolNames()).toHaveLength(2);
 
@@ -171,12 +184,7 @@ describe("AgentSession", () => {
 
 	test("setModel persists to session manager", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		const testModel = { id: "test-model", provider: "test" } as Parameters<
 			typeof session.setModel
@@ -193,12 +201,9 @@ describe("AgentSession", () => {
 	});
 
 	test("setModel returns false when no auth available", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: { getApiKey: async () => undefined },
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(
+			createSessionOptions({ authStorage: { getApiKey: async () => undefined } }),
+		);
 
 		const testModel = { id: "test-model", provider: "no-auth-provider" } as Parameters<
 			typeof session.setModel
@@ -212,12 +217,7 @@ describe("AgentSession", () => {
 
 	test("setThinkingLevel persists to session manager", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		session.setThinkingLevel("high");
 
@@ -227,12 +227,7 @@ describe("AgentSession", () => {
 	});
 
 	test("subscribe and dispose work correctly", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions());
 
 		const events: string[] = [];
 		const unsub = session.subscribe((e) => events.push(e.type));
@@ -254,12 +249,7 @@ describe("AgentSession", () => {
 
 	test("compact calls sessionManager.compact with no arguments by default", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		await session.compact();
 
@@ -270,12 +260,7 @@ describe("AgentSession", () => {
 
 	test("compact passes customInstructions to session_before_compact", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		let receivedInstructions: string | undefined;
 		const ext: Extension = (api) =>
@@ -293,12 +278,7 @@ describe("AgentSession", () => {
 
 	test("compact can be cancelled by extension via session_before_compact", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		const ext: Extension = (api) =>
 			api.on("session_before_compact", () => {
@@ -316,12 +296,7 @@ describe("AgentSession", () => {
 
 	test("compact uses extension-provided custom compaction", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		const ext: Extension = (api) =>
 			api.on("session_before_compact", () => {
@@ -347,12 +322,7 @@ describe("AgentSession", () => {
 			"../session-managers/in-memory-session-manager.js"
 		);
 		const sm = new InMemorySessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		// Seed some messages
 		session.agent.appendMessage({
@@ -377,12 +347,7 @@ describe("AgentSession", () => {
 
 	test("compact returns undefined for default compaction", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		const result = await session.compact();
 		expect(result).toBeUndefined();
@@ -392,12 +357,7 @@ describe("AgentSession", () => {
 
 	test("compact returns the summary from extension-provided compaction", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		const ext: Extension = (api) =>
 			api.on("session_before_compact", () => {
@@ -418,12 +378,7 @@ describe("AgentSession", () => {
 
 	test("compact returns undefined when cancelled by extension", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		const ext: Extension = (api) =>
 			api.on("session_before_compact", () => {
@@ -439,12 +394,7 @@ describe("AgentSession", () => {
 
 	test("compact fires session_compact event with extension-provided summary", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		let capturedSummary = "";
 		let capturedFromExtension = false;
@@ -479,12 +429,7 @@ describe("AgentSession", () => {
 
 	test("onComplete callback receives summary via ExtensionContext.compact", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		const onComplete = vi.fn(() => {});
 		const ext: Extension = (api) =>
@@ -504,12 +449,7 @@ describe("AgentSession", () => {
 
 	test("onComplete callback receives extension-provided summary via ExtensionContext.compact", async () => {
 		const sm = createMockSessionManager();
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		const onComplete = vi.fn(() => {});
 		const ext: Extension = (api) => {
@@ -546,12 +486,7 @@ describe("AgentSession", () => {
 			appendLabel: mockFn(async () => "1"),
 			getEntries: mockFn(async () => []),
 		};
-		const session = new AgentSession({
-			sessionManager: sm,
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
 		const ext: Extension = (api) =>
 			api.on("session_start", (_event, ctx) => {
@@ -574,13 +509,7 @@ describe("AgentSession", () => {
 			{ role: "assistant", content: [{ type: "text", text: "Hi there" }], timestamp: 2 },
 		];
 
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-			messages,
-		});
+		const session = new AgentSession(createSessionOptions({ messages }));
 
 		expect(session.agent.state.messages).toHaveLength(2);
 		expect(session.agent.state.messages[0].role).toBe("user");
@@ -590,12 +519,7 @@ describe("AgentSession", () => {
 	});
 
 	test("omitting messages option starts with empty history", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions());
 
 		expect(session.agent.state.messages).toHaveLength(0);
 
@@ -615,13 +539,7 @@ describe("AgentSession", () => {
 			{ role: "user", content: [{ type: "text", text: "New question" }], timestamp: 3 },
 		];
 
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-			messages,
-		});
+		const session = new AgentSession(createSessionOptions({ messages }));
 
 		expect(session.agent.state.messages).toHaveLength(3);
 		expect(session.agent.state.messages[1].role).toBe("compactionSummary");
@@ -633,12 +551,7 @@ describe("AgentSession", () => {
 	});
 
 	test("authStorage is wired via ModelRegistry as the agent's API key resolver", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(createSessionOptions());
 
 		expect(session.agent.getApiKey).toBeDefined();
 		expect(session.modelRegistry).toBeDefined();
@@ -649,12 +562,9 @@ describe("AgentSession", () => {
 	test("getAllToolDefinitions returns all registered tools", async () => {
 		const tool1 = createTestTool("tool_x");
 		const tool2 = createTestTool("tool_y");
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment({ tools: [tool1] }),
-			systemPrompt: "Prompt.",
-		});
+		const session = new AgentSession(
+			createSessionOptions({ environment: createMockEnvironment({ tools: [tool1] }) }),
+		);
 
 		session.registerTool(tool2);
 
@@ -669,23 +579,24 @@ describe("AgentSession", () => {
 		const messages: AgentMessage[] = [
 			{ role: "user", content: [{ type: "text", text: "Hello" }], timestamp: 1 },
 		];
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Correct prompt.",
-			thinkingLevel: "off",
-			messages,
-			agentOptions: {
-				initialState: {
-					systemPrompt: "Wrong prompt.",
-					model: { id: "wrong-model", provider: "wrong" } as Parameters<typeof session.setModel>[0],
-					thinkingLevel: "high",
-					tools: [],
-					messages: [],
+		const session = new AgentSession(
+			createSessionOptions({
+				systemPrompt: "Correct prompt.",
+				messages,
+				thinkingLevel: "off",
+				agentOptions: {
+					initialState: {
+						systemPrompt: "Wrong prompt.",
+						model: { id: "wrong-model", provider: "wrong" } as Parameters<
+							typeof session.setModel
+						>[0],
+						thinkingLevel: "high",
+						tools: [],
+						messages: [],
+					},
 				},
-			},
-		});
+			}),
+		);
 
 		expect(session.agent.state.systemPrompt).toBe("Correct prompt.");
 		expect(session.agent.state.thinkingLevel).toBe("off");
@@ -700,18 +611,16 @@ describe("AgentSession", () => {
 		console.warn = (msg: string) => warnings.push(msg);
 
 		try {
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: createMockEnvironment(),
-				systemPrompt: "Prompt.",
-				agentOptions: {
-					initialState: {
-						systemPrompt: "Override.",
-						messages: [],
+			const session = new AgentSession(
+				createSessionOptions({
+					agentOptions: {
+						initialState: {
+							systemPrompt: "Override.",
+							messages: [],
+						},
 					},
-				},
-			});
+				}),
+			);
 			await session.dispose();
 		} finally {
 			console.warn = originalWarn;
@@ -722,17 +631,15 @@ describe("AgentSession", () => {
 	});
 
 	test("agentOptions.initialState non-managed fields pass through", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "Prompt.",
-			agentOptions: {
-				initialState: {
-					error: "pre-seeded error",
+		const session = new AgentSession(
+			createSessionOptions({
+				agentOptions: {
+					initialState: {
+						error: "pre-seeded error",
+					},
 				},
-			},
-		});
+			}),
+		);
 
 		expect(session.agent.state.error).toBe("pre-seeded error");
 
@@ -740,12 +647,7 @@ describe("AgentSession", () => {
 	});
 
 	test("getSystemPrompt returns the current system prompt", async () => {
-		const session = new AgentSession({
-			sessionManager: createMockSessionManager(),
-			authStorage: createMockAuthStorage(),
-			environment: createMockEnvironment(),
-			systemPrompt: "My prompt.",
-		});
+		const session = new AgentSession(createSessionOptions({ systemPrompt: "My prompt." }));
 
 		expect(session.getSystemPrompt()).toBe("My prompt.");
 
@@ -759,12 +661,7 @@ describe("AgentSession", () => {
 			const handler = vi.fn(() => {});
 			const ext: Extension = (api) => api.on("session_start", handler);
 
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: createMockEnvironment(),
-				systemPrompt: "Prompt.",
-			});
+			const session = new AgentSession(createSessionOptions());
 
 			await session.loadExtensions([ext]);
 
@@ -777,12 +674,7 @@ describe("AgentSession", () => {
 			const handler = vi.fn(() => {});
 			const ext: Extension = (api) => api.on("session_shutdown", handler);
 
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: createMockEnvironment(),
-				systemPrompt: "Prompt.",
-			});
+			const session = new AgentSession(createSessionOptions());
 
 			await session.loadExtensions([ext]);
 			await session.dispose();
@@ -794,12 +686,7 @@ describe("AgentSession", () => {
 			const tool = createTestTool("ext_registered_tool");
 			const ext: Extension = (api) => api.registerTool(tool);
 
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: createMockEnvironment(),
-				systemPrompt: "Prompt.",
-			});
+			const session = new AgentSession(createSessionOptions());
 
 			await session.loadExtensions([ext]);
 
@@ -817,12 +704,7 @@ describe("AgentSession", () => {
 					handler,
 				});
 
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: createMockEnvironment(),
-				systemPrompt: "Prompt.",
-			});
+			const session = new AgentSession(createSessionOptions());
 
 			await session.loadExtensions([ext]);
 
@@ -841,12 +723,7 @@ describe("AgentSession", () => {
 			const startHandler = vi.fn(() => {});
 			const ext: Extension = (api) => api.on("session_start", startHandler);
 
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: createMockEnvironment(),
-				systemPrompt: "Prompt.",
-			});
+			const session = new AgentSession(createSessionOptions());
 
 			await session.loadExtensions([ext]);
 			expect(startHandler).toHaveBeenCalledTimes(1);
@@ -862,13 +739,7 @@ describe("AgentSession", () => {
 			const handler = vi.fn(() => {});
 			const ext: Extension = (api) => api.on("session_start", handler);
 
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: createMockEnvironment(),
-				systemPrompt: "Prompt.",
-				extensions: [ext],
-			});
+			const session = new AgentSession(createSessionOptions({ extensions: [ext] }));
 
 			await session.loadExtensions();
 
@@ -880,12 +751,7 @@ describe("AgentSession", () => {
 		test("agentEnvironment is exposed to extensions via context", async () => {
 			const environment = createMockEnvironment({ systemAppend: "env-context-test" });
 
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment,
-				systemPrompt: "Prompt.",
-			});
+			const session = new AgentSession(createSessionOptions({ environment }));
 
 			let capturedEnv: unknown;
 			await session.loadExtensions([
@@ -905,12 +771,7 @@ describe("AgentSession", () => {
 		});
 
 		test("extensionRunner is accessible", async () => {
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: createMockEnvironment(),
-				systemPrompt: "Prompt.",
-			});
+			const session = new AgentSession(createSessionOptions());
 
 			expect(session.extensionRunner).toBeDefined();
 			expect(session.extensionRunner.getCommands()).toHaveLength(0);
@@ -919,15 +780,62 @@ describe("AgentSession", () => {
 		});
 
 		test("modelRegistry is accessible and has built-in models", async () => {
-			const session = new AgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: createMockEnvironment(),
-				systemPrompt: "Prompt.",
-			});
+			const session = new AgentSession(createSessionOptions());
 
 			expect(session.modelRegistry).toBeDefined();
 			expect(session.modelRegistry.getAll().length).toBeGreaterThan(0);
+
+			await session.dispose();
+		});
+
+		// ─── Async AgentEnvironment ───────────────────────────────────
+
+		test("createAgentSession pre-resolves async environment", async () => {
+			const asyncEnv: AgentEnvironment = {
+				getSystemMessageAppend: async () => "async-env-append",
+				getTools: async () => [],
+			};
+
+			const { session } = await createAgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: asyncEnv,
+				systemPrompt: "Base.",
+			});
+
+			expect(session.agent.state.systemPrompt).toContain("Base.");
+			expect(session.agent.state.systemPrompt).toContain("async-env-append");
+
+			await session.dispose();
+		});
+
+		test("loadExtensions awaits async environment getSystemMessageAppend", async () => {
+			let callCount = 0;
+			const asyncEnv: AgentEnvironment = {
+				getSystemMessageAppend: async () => {
+					callCount++;
+					return callCount === 1 ? "first-call" : "second-call";
+				},
+				getTools: async () => [],
+			};
+
+			const session = new AgentSession({
+				sessionManager: createMockSessionManager(),
+				authStorage: createMockAuthStorage(),
+				environment: asyncEnv,
+				systemPrompt: "Base.",
+				environmentTools: await asyncEnv.getTools(),
+				environmentAppend: await asyncEnv.getSystemMessageAppend(),
+			});
+
+			// First call was during construction (pre-resolved)
+			expect(session.agent.state.systemPrompt).toContain("first-call");
+			expect(callCount).toBe(1);
+
+			// loadExtensions should await getSystemMessageAppend again
+			await session.loadExtensions();
+			expect(session.agent.state.systemPrompt).toContain("second-call");
+			expect(callCount).toBe(2);
 
 			await session.dispose();
 		});

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -102,12 +102,20 @@ export async function createAgentSession(
 		await sessionManager.appendThinkingLevelChange(thinkingLevel);
 	}
 
-	// 9. Construct and return.
+	// 9. Pre-resolve environment for async-compatible construction.
+	const [environmentTools, environmentAppend] = await Promise.all([
+		options.environment.getTools(),
+		options.environment.getSystemMessageAppend(),
+	]);
+
+	// 10. Construct and return.
 	const session = new AgentSession({
 		...options,
 		model,
 		thinkingLevel,
 		messages: sessionContext.messages,
+		environmentTools,
+		environmentAppend,
 	});
 	return { session };
 }
@@ -163,6 +171,25 @@ export interface AgentSessionOptions {
 
 	/** Additional pi-agent-core Agent options. */
 	agentOptions?: Partial<AgentOptions>;
+
+	/**
+	 * Pre-resolved tools from the environment.
+	 *
+	 * When provided (e.g. by {@link createAgentSession}), these are used
+	 * directly. Otherwise the constructor calls {@link AgentEnvironment.getTools}
+	 * synchronously — callers using an async environment must pre-resolve.
+	 */
+	environmentTools?: ToolDefinition[];
+
+	/**
+	 * Pre-resolved system message append from the environment.
+	 *
+	 * When provided (e.g. by {@link createAgentSession}), this is used
+	 * directly. Otherwise the constructor calls
+	 * {@link AgentEnvironment.getSystemMessageAppend} synchronously —
+	 * callers using an async environment must pre-resolve.
+	 */
+	environmentAppend?: string | undefined;
 }
 
 /** Event types emitted by AgentSession (superset of pi-agent-core AgentEvent). */
@@ -223,9 +250,16 @@ export class AgentSession {
 		this._extensionRunner.setUIProvider(this.uiProvider);
 		this._extensionRunner.setModelRegistry(this.modelRegistry);
 
-		// Resolve environment at startup (called once)
-		this._environmentAppend = this._environment.getSystemMessageAppend();
-		const environmentTools = this._environment.getTools();
+		// Resolve environment at startup (called once).
+		// Use pre-resolved values when available (for async environments);
+		// otherwise call directly. The direct-construction path requires
+		// a sync-compatible environment — use createAgentSession() for
+		// async environments.
+		this._environmentAppend =
+			options.environmentAppend ??
+			(this._environment.getSystemMessageAppend() as string | undefined);
+		const environmentTools =
+			options.environmentTools ?? (this._environment.getTools() as ToolDefinition[]);
 
 		// Register environment tools
 		for (const tool of environmentTools) {
@@ -296,7 +330,7 @@ export class AgentSession {
 
 		// Refresh the environment append now that extensions may have modified the
 		// environment (e.g. by registering skills on a SkillSupportedAgentEnvironment).
-		this._environmentAppend = this._environment.getSystemMessageAppend();
+		this._environmentAppend = await this._environment.getSystemMessageAppend();
 		this._applyToolChanges();
 		this._registerSkillCommands();
 	}
@@ -315,7 +349,7 @@ export class AgentSession {
 		await this._extensionRunner.emit({ type: "session_start" });
 
 		// Refresh environment append and skill commands after reload.
-		this._environmentAppend = this._environment.getSystemMessageAppend();
+		this._environmentAppend = await this._environment.getSystemMessageAppend();
 		this._applyToolChanges();
 		this._registerSkillCommands();
 	}

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -40,7 +40,10 @@ export interface CreateAgentSessionResult {
  * but without `messages` — the factory always derives messages from
  * {@link SessionManager.buildSessionContext}.
  */
-export type CreateAgentSessionOptions = Omit<AgentSessionOptions, "messages">;
+export type CreateAgentSessionOptions = Omit<
+	AgentSessionOptions,
+	"messages" | "environmentTools" | "environmentAppend"
+>;
 
 /**
  * Async factory that creates an AgentSession with session restore.
@@ -175,21 +178,22 @@ export interface AgentSessionOptions {
 	/**
 	 * Pre-resolved tools from the environment.
 	 *
-	 * When provided (e.g. by {@link createAgentSession}), these are used
-	 * directly. Otherwise the constructor calls {@link AgentEnvironment.getTools}
-	 * synchronously — callers using an async environment must pre-resolve.
+	 * Must be provided by all callers. Use {@link createAgentSession} for
+	 * automatic pre-resolution from an {@link AgentEnvironment} (including
+	 * async environments). Direct construction requires callers to resolve
+	 * these values themselves.
 	 */
-	environmentTools?: ToolDefinition[];
+	environmentTools: ToolDefinition[];
 
 	/**
 	 * Pre-resolved system message append from the environment.
 	 *
-	 * When provided (e.g. by {@link createAgentSession}), this is used
-	 * directly. Otherwise the constructor calls
-	 * {@link AgentEnvironment.getSystemMessageAppend} synchronously —
-	 * callers using an async environment must pre-resolve.
+	 * Must be provided by all callers. Use {@link createAgentSession} for
+	 * automatic pre-resolution from an {@link AgentEnvironment} (including
+	 * async environments). Direct construction requires callers to resolve
+	 * these values themselves.
 	 */
-	environmentAppend?: string | undefined;
+	environmentAppend: string | undefined;
 }
 
 /** Event types emitted by AgentSession (superset of pi-agent-core AgentEvent). */
@@ -250,16 +254,9 @@ export class AgentSession {
 		this._extensionRunner.setUIProvider(this.uiProvider);
 		this._extensionRunner.setModelRegistry(this.modelRegistry);
 
-		// Resolve environment at startup (called once).
-		// Use pre-resolved values when available (for async environments);
-		// otherwise call directly. The direct-construction path requires
-		// a sync-compatible environment — use createAgentSession() for
-		// async environments.
-		this._environmentAppend =
-			options.environmentAppend ??
-			(this._environment.getSystemMessageAppend() as string | undefined);
-		const environmentTools =
-			options.environmentTools ?? (this._environment.getTools() as ToolDefinition[]);
+		// Use pre-resolved environment values.
+		this._environmentAppend = options.environmentAppend;
+		const environmentTools = options.environmentTools;
 
 		// Register environment tools
 		for (const tool of environmentTools) {

--- a/packages/otter-agent/src/session/skill-commands.test.ts
+++ b/packages/otter-agent/src/session/skill-commands.test.ts
@@ -68,6 +68,8 @@ function createSession(env: AgentEnvironment): AgentSession {
 		authStorage: createMockAuthStorage(),
 		environment: env,
 		systemPrompt: "You are a test agent.",
+		environmentTools: env.getTools(),
+		environmentAppend: env.getSystemMessageAppend(),
 	});
 }
 

--- a/packages/otter-agent/src/utils/maybe-promise.ts
+++ b/packages/otter-agent/src/utils/maybe-promise.ts
@@ -1,0 +1,8 @@
+/**
+ * A value that may be synchronous or wrapped in a Promise.
+ *
+ * Allows interface methods to accept both sync and async implementations.
+ * Callers uniformly `await` the result — `await value` is a no-op
+ * when `value` is not a Thenable.
+ */
+export type MaybePromise<T> = T | Promise<T>;


### PR DESCRIPTION
## Summary

Define a `MaybePromise<T> = T | Promise<T>` utility type and use it across all five core interfaces so implementations can return either sync or async values. Callers uniformly `await` the result — `await value` is a no-op when `value` is not a Thenable.

Closes #106

## Changes

### Core type
- **New:** `MaybePromise<T>` utility type in `src/utils/maybe-promise.ts`

### Interfaces updated (18 methods total)
| Interface | Methods |
|---|---|
| `SessionManager` | 9 methods: `appendMessage`, `buildSessionContext`, `compact`, `appendCustomEntry`, `appendCustomMessageEntry`, `appendModelChange`, `appendThinkingLevelChange`, `appendLabel`, `getEntries` |
| `AuthStorage` | 1 method: `getApiKey` |
| `AgentEnvironment` | 2 methods: `getTools`, `getSystemMessageAppend` |
| `UIProvider` | 5 methods: `dialog`, `confirm`, `input`, `select`, `notify` |
| `ResourceLoader` | 1 method: `getResources` |

### AgentSession changes
- `environmentTools` and `environmentAppend` are now **required** on `AgentSessionOptions` — the constructor is always sync-safe with no type-unsafe fallbacks
- `CreateAgentSessionOptions` omits these fields — the factory pre-resolves them via `Promise.all`
- `loadExtensions()` and `reload()` now `await getSystemMessageAppend()` for async environments

### Tests
- All 630 existing tests pass unchanged
- Added 2 new async environment tests (pre-resolution + loadExtensions re-fetch)
- Refactored test call sites using `createSessionOptions()` helpers

## Verification

- ✅ `npm run build` succeeds
- ✅ `npm run lint` passes
- ✅ 632 tests pass
- ✅ Two independent code reviews approved