### PR TITLE
feat: add @otter-agent/environment-registry package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1520,6 +1520,10 @@
 			"resolved": "packages/otter-agent",
 			"link": true
 		},
+		"node_modules/@otter-agent/environment-registry": {
+			"resolved": "packages/environment-registry",
+			"link": true
+		},
 		"node_modules/@otter-agent/rpc": {
 			"resolved": "packages/rpc",
 			"link": true
@@ -5120,6 +5124,14 @@
 			"license": "ISC",
 			"peerDependencies": {
 				"zod": "^3.25.28 || ^4"
+			}
+		},
+		"packages/environment-registry": {
+			"name": "@otter-agent/environment-registry",
+			"version": "0.0.1",
+			"dependencies": {
+				"@otter-agent/core": "*",
+				"@sinclair/typebox": "^0.34.0"
 			}
 		},
 		"packages/otter-agent": {

--- a/packages/environment-registry/package.json
+++ b/packages/environment-registry/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@otter-agent/environment-registry",
+	"version": "0.0.1",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": ["dist/"],
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc",
+		"test": "vitest run",
+		"dev": "tsc --watch"
+	},
+	"dependencies": {
+		"@otter-agent/core": "*",
+		"@sinclair/typebox": "^0.34.0"
+	}
+}

--- a/packages/environment-registry/src/environments/no-op/index.ts
+++ b/packages/environment-registry/src/environments/no-op/index.ts
@@ -1,0 +1,41 @@
+import type { AgentEnvironment, ComponentTemplate, ToolDefinition } from "@otter-agent/core";
+import { Type } from "@sinclair/typebox";
+
+/**
+ * AgentEnvironment that provides no tools and no system message appendix.
+ *
+ * Useful as a default or placeholder when no real environment is needed.
+ */
+export class NoOpAgentEnvironment implements AgentEnvironment {
+	getSystemMessageAppend(): string | undefined {
+		return undefined;
+	}
+
+	getTools(): ToolDefinition[] {
+		return [];
+	}
+}
+
+const NoOpConfigSchema = Type.Object({});
+
+/**
+ * ComponentTemplate for {@link NoOpAgentEnvironment}.
+ *
+ * Accepts no configuration — `configSchema()` is an empty object.
+ */
+export const NoOpAgentEnvironmentTemplate: ComponentTemplate<
+	typeof NoOpConfigSchema,
+	AgentEnvironment
+> = {
+	configSchema() {
+		return NoOpConfigSchema;
+	},
+
+	defaultConfig() {
+		return {};
+	},
+
+	build(_config) {
+		return new NoOpAgentEnvironment();
+	},
+};

--- a/packages/environment-registry/src/index.ts
+++ b/packages/environment-registry/src/index.ts
@@ -1,0 +1,20 @@
+// Re-export AgentEnvironment type from core.
+export type { AgentEnvironment } from "@otter-agent/core";
+
+/**
+ * Options for {@link buildAgentEnvironment}.
+ */
+export interface BuildAgentEnvironmentOptions {
+	/** The registered environment name (e.g. "no-op", "just-bash"). */
+	name: string;
+	/**
+	 * Configuration to merge with the environment template's defaults.
+	 * Pass null or undefined to use defaults as-is.
+	 */
+	config: unknown;
+}
+
+// Eagerly populate the registry with built-in environments.
+import "./registry/register-environments.js";
+
+export { buildAgentEnvironment } from "./registry/registry.js";

--- a/packages/environment-registry/src/registry/register-environments.ts
+++ b/packages/environment-registry/src/registry/register-environments.ts
@@ -1,0 +1,4 @@
+import { NoOpAgentEnvironmentTemplate } from "../environments/no-op/index.js";
+import { registerEnvironment } from "./registry.js";
+
+registerEnvironment("no-op", NoOpAgentEnvironmentTemplate);

--- a/packages/environment-registry/src/registry/registry.test.ts
+++ b/packages/environment-registry/src/registry/registry.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentEnvironment } from "../index.js";
+
+describe("buildAgentEnvironment", () => {
+	it("builds 'no-op' environment with default config", () => {
+		const env = buildAgentEnvironment({ name: "no-op", config: {} });
+		expect(env.getSystemMessageAppend()).toBeUndefined();
+		expect(env.getTools()).toEqual([]);
+	});
+
+	it("builds 'no-op' environment with null config (uses defaults)", () => {
+		const env = buildAgentEnvironment({ name: "no-op", config: null });
+		expect(env.getSystemMessageAppend()).toBeUndefined();
+		expect(env.getTools()).toEqual([]);
+	});
+
+	it("builds 'no-op' environment with undefined config (uses defaults)", () => {
+		const env = buildAgentEnvironment({ name: "no-op", config: undefined });
+		expect(env.getSystemMessageAppend()).toBeUndefined();
+		expect(env.getTools()).toEqual([]);
+	});
+
+	it("throws Error for unknown environment name", () => {
+		expect(() => buildAgentEnvironment({ name: "nonexistent", config: {} })).toThrow(
+			'Unknown environment "nonexistent". Registered environments: no-op',
+		);
+	});
+});

--- a/packages/environment-registry/src/registry/registry.ts
+++ b/packages/environment-registry/src/registry/registry.ts
@@ -1,0 +1,57 @@
+import type { AgentEnvironment, ComponentTemplate } from "@otter-agent/core";
+import { validateComponentConfig } from "@otter-agent/core";
+import type { TSchema } from "@sinclair/typebox";
+import type { BuildAgentEnvironmentOptions } from "../index.js";
+
+/**
+ * Internal registry mapping environment names to their templates.
+ */
+const registry = new Map<string, ComponentTemplate<TSchema, AgentEnvironment>>();
+
+/**
+ * Register an environment template under the given name.
+ *
+ * Internal-only — not exported from the package.
+ */
+export function registerEnvironment(
+	name: string,
+	template: ComponentTemplate<TSchema, AgentEnvironment>,
+): void {
+	registry.set(name, template);
+}
+
+/**
+ * Build an {@link AgentEnvironment} by name.
+ *
+ * Workflow:
+ * 1. Look up the registered template by name. Throws if not found.
+ * 2. Merge the provided config with the template's defaults.
+ *    If config is null or undefined, uses defaults as-is.
+ * 3. Validate the merged config against the template's TypeBox schema.
+ * 4. Build and return the AgentEnvironment instance.
+ *
+ * @param options - The environment name and optional config.
+ * @returns A built AgentEnvironment instance.
+ * @throws {Error} If no template is registered under the given name.
+ * @throws {import("@otter-agent/core").ComponentConfigValidationError} If config validation fails.
+ */
+export function buildAgentEnvironment(options: BuildAgentEnvironmentOptions): AgentEnvironment {
+	const template = registry.get(options.name);
+
+	if (!template) {
+		const registered = [...registry.keys()].join(", ");
+		throw new Error(
+			`Unknown environment "${options.name}". Registered environments: ${registered}`,
+		);
+	}
+
+	const rawConfig =
+		options.config !== null &&
+		options.config !== undefined &&
+		typeof options.config === "object" &&
+		!Array.isArray(options.config)
+			? (options.config as Record<string, unknown>)
+			: {};
+
+	return validateComponentConfig(template, rawConfig);
+}

--- a/packages/environment-registry/tsconfig.json
+++ b/packages/environment-registry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #112

Adds a new monorepo package `@otter-agent/environment-registry` that provides a name-based registry for `ComponentTemplate<TSchema, AgentEnvironment>` instances, with a `buildAgentEnvironment()` factory that handles lookup, config merging, validation, and building.

## Public API

- `buildAgentEnvironment(options: BuildAgentEnvironmentOptions): AgentEnvironment` — looks up a registered template by name, merges config with defaults, validates against the TypeBox schema, and builds the instance
- `BuildAgentEnvironmentOptions` — `{ name: string; config: unknown }`
- `AgentEnvironment` — re-exported type from `@otter-agent/core`

## Package Structure

```
packages/environment-registry/
├── package.json
├── tsconfig.json
└── src/
    ├── index.ts                          # public API + eager registration side-effect
    ├── registry/
    │   ├── registry.ts                   # Map, registerEnvironment(), buildAgentEnvironment()
    │   ├── register-environments.ts      # registers built-in environments
    │   └── registry.test.ts              # 4 tests
    └── environments/
        └── no-op/
            └── index.ts                  # NoOpAgentEnvironment class + template
```

## Design Decisions

- **Eager registration**: `index.ts` imports `register-environments.js` as a side effect, populating the registry on first import
- **Internal-only `registerEnvironment()`**: not exported from the package
- **Config merging**: delegates to `validateComponentConfig` from `@otter-agent/core`; null/undefined/non-object config falls back to defaults via a sound runtime type guard
- **Unknown name error**: plain `Error` listing all registered environment names
- **NoOpAgentEnvironment**: provides empty tools array and undefined system message append; template uses `Type.Object({})` schema (no config)

## Verification

- ✅ Build passes (`npm run build`)
- ✅ Lint passes (`npm run lint`)
- ✅ All 565 tests pass (including 4 new registry tests)
- ✅ No changes to existing packages
- ✅ Two independent code reviews both approved