### PR TITLE
feat: add @otter-agent/extension-registry package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1524,6 +1524,10 @@
 			"resolved": "packages/environment-registry",
 			"link": true
 		},
+		"node_modules/@otter-agent/extension-registry": {
+			"resolved": "packages/extension-registry",
+			"link": true
+		},
 		"node_modules/@otter-agent/rpc": {
 			"resolved": "packages/rpc",
 			"link": true
@@ -5128,6 +5132,14 @@
 		},
 		"packages/environment-registry": {
 			"name": "@otter-agent/environment-registry",
+			"version": "0.0.1",
+			"dependencies": {
+				"@otter-agent/core": "*",
+				"@sinclair/typebox": "^0.34.0"
+			}
+		},
+		"packages/extension-registry": {
+			"name": "@otter-agent/extension-registry",
 			"version": "0.0.1",
 			"dependencies": {
 				"@otter-agent/core": "*",

--- a/packages/extension-registry/package.json
+++ b/packages/extension-registry/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@otter-agent/extension-registry",
+	"version": "0.0.1",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": ["dist/"],
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc",
+		"test": "vitest run",
+		"dev": "tsc --watch"
+	},
+	"dependencies": {
+		"@otter-agent/core": "*",
+		"@sinclair/typebox": "^0.34.0"
+	}
+}

--- a/packages/extension-registry/src/extensions/no-op/index.ts
+++ b/packages/extension-registry/src/extensions/no-op/index.ts
@@ -1,0 +1,32 @@
+import type { ComponentTemplate, Extension } from "@otter-agent/core";
+import { Type } from "@sinclair/typebox";
+
+/**
+ * Extension that does nothing.
+ *
+ * Useful as a default or placeholder when no real extension is needed.
+ */
+const NoOpExtension: Extension = (_api) => {
+	// no-op
+};
+
+const NoOpConfigSchema = Type.Object({});
+
+/**
+ * ComponentTemplate for {@link NoOpExtension}.
+ *
+ * Accepts no configuration — `configSchema()` is an empty object.
+ */
+export const NoOpExtensionTemplate: ComponentTemplate<typeof NoOpConfigSchema, Extension> = {
+	configSchema() {
+		return NoOpConfigSchema;
+	},
+
+	defaultConfig() {
+		return {};
+	},
+
+	build(_config) {
+		return NoOpExtension;
+	},
+};

--- a/packages/extension-registry/src/index.ts
+++ b/packages/extension-registry/src/index.ts
@@ -1,0 +1,20 @@
+// Re-export Extension type from core.
+export type { Extension } from "@otter-agent/core";
+
+/**
+ * Options for {@link buildExtension}.
+ */
+export interface BuildExtensionOptions {
+	/** The registered extension name (e.g. "no-op"). */
+	name: string;
+	/**
+	 * Configuration to merge with the extension template's defaults.
+	 * Pass null or undefined to use defaults as-is.
+	 */
+	config: unknown;
+}
+
+// Eagerly populate the registry with built-in extensions.
+import "./registry/register-extensions.js";
+
+export { buildExtension } from "./registry/registry.js";

--- a/packages/extension-registry/src/registry/register-extensions.ts
+++ b/packages/extension-registry/src/registry/register-extensions.ts
@@ -1,0 +1,4 @@
+import { NoOpExtensionTemplate } from "../extensions/no-op/index.js";
+import { registerExtension } from "./registry.js";
+
+registerExtension("no-op", NoOpExtensionTemplate);

--- a/packages/extension-registry/src/registry/registry.test.ts
+++ b/packages/extension-registry/src/registry/registry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildExtension } from "../index.js";
+
+describe("buildExtension", () => {
+	it("builds 'no-op' extension with default config", () => {
+		const ext = buildExtension({ name: "no-op", config: {} });
+		expect(typeof ext).toBe("function");
+	});
+
+	it("builds 'no-op' extension with null config (uses defaults)", () => {
+		const ext = buildExtension({ name: "no-op", config: null });
+		expect(typeof ext).toBe("function");
+	});
+
+	it("builds 'no-op' extension with undefined config (uses defaults)", () => {
+		const ext = buildExtension({ name: "no-op", config: undefined });
+		expect(typeof ext).toBe("function");
+	});
+
+	it("throws Error for unknown extension name", () => {
+		expect(() => buildExtension({ name: "nonexistent", config: {} })).toThrow(
+			'Unknown extension "nonexistent". Registered extensions: no-op',
+		);
+	});
+});

--- a/packages/extension-registry/src/registry/registry.ts
+++ b/packages/extension-registry/src/registry/registry.ts
@@ -1,0 +1,55 @@
+import type { ComponentTemplate, Extension } from "@otter-agent/core";
+import { validateComponentConfig } from "@otter-agent/core";
+import type { TSchema } from "@sinclair/typebox";
+import type { BuildExtensionOptions } from "../index.js";
+
+/**
+ * Internal registry mapping extension names to their templates.
+ */
+const registry = new Map<string, ComponentTemplate<TSchema, Extension>>();
+
+/**
+ * Register an extension template under the given name.
+ *
+ * Internal-only — not exported from the package.
+ */
+export function registerExtension(
+	name: string,
+	template: ComponentTemplate<TSchema, Extension>,
+): void {
+	registry.set(name, template);
+}
+
+/**
+ * Build an {@link Extension} by name.
+ *
+ * Workflow:
+ * 1. Look up the registered template by name. Throws if not found.
+ * 2. Merge the provided config with the template's defaults.
+ *    If config is null or undefined, uses defaults as-is.
+ * 3. Validate the merged config against the template's TypeBox schema.
+ * 4. Build and return the Extension function.
+ *
+ * @param options - The extension name and optional config.
+ * @returns A built Extension function.
+ * @throws {Error} If no template is registered under the given name.
+ * @throws {import("@otter-agent/core").ComponentConfigValidationError} If config validation fails.
+ */
+export function buildExtension(options: BuildExtensionOptions): Extension {
+	const template = registry.get(options.name);
+
+	if (!template) {
+		const registered = [...registry.keys()].join(", ");
+		throw new Error(`Unknown extension "${options.name}". Registered extensions: ${registered}`);
+	}
+
+	const rawConfig =
+		options.config !== null &&
+		options.config !== undefined &&
+		typeof options.config === "object" &&
+		!Array.isArray(options.config)
+			? (options.config as Record<string, unknown>)
+			: {};
+
+	return validateComponentConfig(template, rawConfig);
+}

--- a/packages/extension-registry/tsconfig.json
+++ b/packages/extension-registry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
Closes #114

## Summary

Adds `@otter-agent/extension-registry` — a new package that mirrors `@otter-agent/environment-registry` but for extensions.

### What's included

- **Registry** (`registry.ts`): Internal `Map<string, ComponentTemplate<TSchema, Extension>>` with `registerExtension()` and `buildExtension()` functions
- **No-op extension** (`extensions/no-op/`): `NoOpExtensionTemplate` with empty config schema, produces a no-op `Extension` function
- **Eager registration** (`register-extensions.ts`): Built-in extensions registered at import time
- **Public API** (`index.ts`): Re-exports `Extension` type, `BuildExtensionOptions` interface, and `buildExtension()`
- **4 tests**: Default/null/undefined config + unknown name error

### Acceptance criteria

| Criteria | Status |
|---|---|
| Package builds cleanly | ✅ |
| All tests pass (569/569) | ✅ |
| No existing files modified | ✅ |
| Structurally identical to environment-registry | ✅ |

### Code review

Independent code review passed with **Approve** verdict. See [review comment on #114](https://github.com/BowerJames/OtterAgent/issues/114#issuecomment-4292636812).