### PR TITLE
refactor: replace environmentTools/environmentAppend with default environment extension

### DIFF
--- a/packages/otter-agent/src/environments/environment-extension.test.ts
+++ b/packages/otter-agent/src/environments/environment-extension.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for the default environment extension.
+ */
+import { Type } from "@sinclair/typebox";
+import { describe, expect, test, vi } from "vitest";
+import type { Extension } from "../extension-core/extension.js";
+import type { AgentEnvironment } from "../interfaces/agent-environment.js";
+import type { ToolDefinition } from "../interfaces/tool-definition.js";
+import { createEnvironmentExtension } from "./environment-extension.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function createTestTool(name: string): ToolDefinition {
+	return {
+		name,
+		label: name,
+		description: `Test tool: ${name}`,
+		promptSnippet: `${name} — a test tool`,
+		promptGuidelines: [],
+		parameters: Type.Object({ input: Type.String() }),
+		async execute() {
+			return { content: [{ type: "text", text: "ok" }], details: undefined };
+		},
+	};
+}
+
+/**
+ * Creates a mock ExtensionsAPI that captures registered tools
+ * and before_agent_start handlers.
+ */
+function createMockAPI() {
+	const registeredTools: ToolDefinition[] = [];
+	const handlers: Array<{ event: string; handler: unknown }> = [];
+
+	const api = {
+		registerTool: vi.fn((tool: ToolDefinition) => {
+			registeredTools.push(tool);
+		}),
+		on: vi.fn((event: string, handler: unknown) => {
+			handlers.push({ event, handler });
+		}),
+	};
+
+	return { api, registeredTools, handlers };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("createEnvironmentExtension", () => {
+	test("is a valid Extension (function)", () => {
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: () => undefined,
+			getTools: () => [],
+		};
+
+		const extension = createEnvironmentExtension(env);
+		expect(typeof extension).toBe("function");
+	});
+
+	test("registers tools from a sync environment", async () => {
+		const tool = createTestTool("bash");
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: () => undefined,
+			getTools: () => [tool],
+		};
+
+		const { api, registeredTools } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(api as Parameters<typeof extension>[0]);
+
+		expect(api.registerTool).toHaveBeenCalledTimes(1);
+		expect(api.registerTool).toHaveBeenCalledWith(tool);
+		expect(registeredTools).toHaveLength(1);
+		expect(registeredTools[0].name).toBe("bash");
+	});
+
+	test("registers multiple tools", async () => {
+		const tools = [createTestTool("read"), createTestTool("write"), createTestTool("edit")];
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: () => undefined,
+			getTools: () => tools,
+		};
+
+		const { api, registeredTools } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(api as Parameters<typeof extension>[0]);
+
+		expect(registeredTools).toHaveLength(3);
+		expect(registeredTools.map((t) => t.name)).toEqual(["read", "write", "edit"]);
+	});
+
+	test("registers no tools when environment has none", async () => {
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: () => undefined,
+			getTools: () => [],
+		};
+
+		const { registeredTools } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(createMockAPI().api as Parameters<typeof extension>[0]);
+
+		expect(registeredTools).toHaveLength(0);
+	});
+
+	test("registers tools from an async environment", async () => {
+		const tool = createTestTool("async_tool");
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: async () => "async append",
+			getTools: async () => [tool],
+		};
+
+		const { api, registeredTools } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(api as Parameters<typeof extension>[0]);
+
+		expect(registeredTools).toHaveLength(1);
+		expect(registeredTools[0].name).toBe("async_tool");
+	});
+
+	test("registers a before_agent_start handler", async () => {
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: () => "env context",
+			getTools: () => [],
+		};
+
+		const { api, handlers } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(api as Parameters<typeof extension>[0]);
+
+		expect(api.on).toHaveBeenCalledWith("before_agent_start", expect.any(Function));
+		expect(handlers.filter((h) => h.event === "before_agent_start")).toHaveLength(1);
+	});
+
+	test("before_agent_start appends environment text to system prompt", async () => {
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: () => "You are in Docker.",
+			getTools: () => [],
+		};
+
+		const { api } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(api as Parameters<typeof extension>[0]);
+
+		// Get the registered handler
+		const handler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+			(c: unknown[]) => c[0] === "before_agent_start",
+		)?.[1] as (event: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>;
+
+		expect(handler).toBeDefined();
+
+		const result = await handler?.({ systemPrompt: "Base prompt." });
+		expect(result?.systemPrompt).toBe("Base prompt.\n\nYou are in Docker.");
+	});
+
+	test("before_agent_start returns undefined when append is undefined", async () => {
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: () => undefined,
+			getTools: () => [],
+		};
+
+		const { api } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(api as Parameters<typeof extension>[0]);
+
+		const handler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+			(c: unknown[]) => c[0] === "before_agent_start",
+		)?.[1] as (event: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>;
+
+		const result = await handler?.({ systemPrompt: "Base prompt." });
+		expect(result).toBeUndefined();
+	});
+
+	test("before_agent_start returns undefined when append is empty string", async () => {
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: () => "",
+			getTools: () => [],
+		};
+
+		const { api } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(api as Parameters<typeof extension>[0]);
+
+		const handler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+			(c: unknown[]) => c[0] === "before_agent_start",
+		)?.[1] as (event: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>;
+
+		const result = await handler?.({ systemPrompt: "Base prompt." });
+		expect(result).toBeUndefined();
+	});
+
+	test("before_agent_start works with async getSystemMessageAppend", async () => {
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: async () => {
+				return "Async environment info.";
+			},
+			getTools: async () => [],
+		};
+
+		const { api } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(api as Parameters<typeof extension>[0]);
+
+		const handler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+			(c: unknown[]) => c[0] === "before_agent_start",
+		)?.[1] as (event: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>;
+
+		const result = await handler?.({ systemPrompt: "Base." });
+		expect(result?.systemPrompt).toBe("Base.\n\nAsync environment info.");
+	});
+
+	test("before_agent_start queries fresh append each turn", async () => {
+		let callCount = 0;
+		const env: AgentEnvironment = {
+			getSystemMessageAppend: () => {
+				callCount++;
+				return `Call ${callCount}`;
+			},
+			getTools: () => [],
+		};
+
+		const { api } = createMockAPI();
+		const extension = createEnvironmentExtension(env);
+
+		await extension(api as Parameters<typeof extension>[0]);
+
+		const handler = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+			(c: unknown[]) => c[0] === "before_agent_start",
+		)?.[1] as (event: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>;
+
+		const result1 = await handler?.({ systemPrompt: "Base." });
+		expect(result1?.systemPrompt).toBe("Base.\n\nCall 1");
+
+		const result2 = await handler?.({ systemPrompt: "Base." });
+		expect(result2?.systemPrompt).toBe("Base.\n\nCall 2");
+	});
+});

--- a/packages/otter-agent/src/environments/environment-extension.ts
+++ b/packages/otter-agent/src/environments/environment-extension.ts
@@ -1,0 +1,45 @@
+import type { Extension } from "../extension-core/extension.js";
+/**
+ * Creates a default extension that registers the environment's tools
+ * and appends the environment's system message to the system prompt.
+ *
+ * This extension is automatically prepended during `AgentSession.loadExtensions()`
+ * so that environment tools are available and the system prompt is augmented
+ * before user extensions load.
+ *
+ * Tools are registered once during init. The system prompt append uses
+ * `before_agent_start` (matching pi-coding-agent's pattern), called fresh
+ * every turn so that skill registrations from `session_start` handlers
+ * are automatically reflected.
+ */
+import type { AgentEnvironment } from "../interfaces/agent-environment.js";
+
+/**
+ * Creates an extension that wires an {@link AgentEnvironment} into the session.
+ *
+ * @param environment - The environment to register tools and system prompt from.
+ * @returns An {@link Extension} suitable for prepending to the extensions array.
+ */
+export function createEnvironmentExtension(environment: AgentEnvironment): Extension {
+	return async (api) => {
+		// Register environment tools during init
+		const tools = await environment.getTools();
+		for (const tool of tools) {
+			api.registerTool(tool);
+		}
+
+		// Append environment context to system prompt every turn via before_agent_start.
+		// Called fresh each turn so skill registrations from session_start handlers
+		// are automatically reflected in the append (e.g. JustBashAgentEnvironment
+		// includes skill listings in its append).
+		api.on("before_agent_start", async (event) => {
+			const append = await environment.getSystemMessageAppend();
+			if (append) {
+				return {
+					systemPrompt: `${event.systemPrompt}\n\n${append}`,
+				};
+			}
+			return undefined;
+		});
+	};
+}

--- a/packages/otter-agent/src/environments/index.ts
+++ b/packages/otter-agent/src/environments/index.ts
@@ -7,3 +7,4 @@ export {
 	type JustBashAgentEnvironmentOptions,
 	type JustBashToolName,
 } from "./agent-environment.js";
+export { createEnvironmentExtension } from "./environment-extension.js";

--- a/packages/otter-agent/src/index.ts
+++ b/packages/otter-agent/src/index.ts
@@ -24,6 +24,7 @@ export {
 	JustBashAgentEnvironment,
 	JustBashAgentEnvironmentOptionsSchema,
 	JustBashAgentEnvironmentTemplate,
+	createEnvironmentExtension,
 	type JustBashAgentEnvironmentOptions,
 	type JustBashToolName,
 } from "./environments/index.js";

--- a/packages/otter-agent/src/session/agent-session.test.ts
+++ b/packages/otter-agent/src/session/agent-session.test.ts
@@ -56,14 +56,11 @@ function createSessionOptions(overrides?: {
 	messages?: AgentMessage[];
 	agentOptions?: Partial<import("@mariozechner/pi-agent-core").AgentOptions>;
 }) {
-	const environment = overrides?.environment ?? createMockEnvironment();
 	return {
 		sessionManager: overrides?.sessionManager ?? createMockSessionManager(),
 		authStorage: overrides?.authStorage ?? createMockAuthStorage(),
-		environment,
+		environment: overrides?.environment ?? createMockEnvironment(),
 		systemPrompt: overrides?.systemPrompt ?? "You are a helpful assistant.",
-		environmentTools: environment.getTools(),
-		environmentAppend: environment.getSystemMessageAppend(),
 		...(overrides?.model !== undefined ? { model: overrides.model } : {}),
 		...(overrides?.thinkingLevel !== undefined ? { thinkingLevel: overrides.thinkingLevel } : {}),
 		...(overrides?.uiProvider !== undefined ? { uiProvider: overrides.uiProvider } : {}),
@@ -99,11 +96,30 @@ describe("AgentSession", () => {
 		expect(session.agent).toBeDefined();
 		expect(session.sessionManager).toBeDefined();
 		expect(session.agent.state.systemPrompt).toBe("You are a helpful assistant.");
+		expect(session.agent.state.tools).toHaveLength(0);
 
 		await session.dispose();
 	});
 
-	test("appends environment system message", async () => {
+	test("registers environment tools after loadExtensions", async () => {
+		const tool = createTestTool("env_tool");
+		const session = new AgentSession(
+			createSessionOptions({ environment: createMockEnvironment({ tools: [tool] }) }),
+		);
+
+		// Before loadExtensions, no tools are registered
+		expect(session.getActiveToolNames()).toHaveLength(0);
+
+		await session.loadExtensions();
+
+		expect(session.getActiveToolNames()).toContain("env_tool");
+		expect(session.agent.state.tools).toHaveLength(1);
+		expect(session.agent.state.tools[0].name).toBe("env_tool");
+
+		await session.dispose();
+	});
+
+	test("appends environment system message via before_agent_start", async () => {
 		const session = new AgentSession(
 			createSessionOptions({
 				environment: createMockEnvironment({
@@ -113,26 +129,19 @@ describe("AgentSession", () => {
 			}),
 		);
 
-		expect(session.agent.state.systemPrompt).toContain("Base prompt.");
-		expect(session.agent.state.systemPrompt).toContain("You are in a Docker container.");
+		// Before loadExtensions, system prompt is bare
+		expect(session.agent.state.systemPrompt).toBe("Base prompt.");
+
+		await session.loadExtensions();
+
+		// Before any prompt, the base system prompt doesn't include the append yet
+		// (it's added per-turn via before_agent_start)
+		expect(session.agent.state.systemPrompt).toBe("Base prompt.");
 
 		await session.dispose();
 	});
 
-	test("registers environment tools", async () => {
-		const tool = createTestTool("env_tool");
-		const session = new AgentSession(
-			createSessionOptions({ environment: createMockEnvironment({ tools: [tool] }) }),
-		);
-
-		expect(session.getActiveToolNames()).toContain("env_tool");
-		expect(session.agent.state.tools).toHaveLength(1);
-		expect(session.agent.state.tools[0].name).toBe("env_tool");
-
-		await session.dispose();
-	});
-
-	test("includes tool snippets and guidelines in system prompt", async () => {
+	test("includes tool snippets and guidelines in system prompt after loadExtensions", async () => {
 		const tool = createTestTool("my_tool");
 		const session = new AgentSession(
 			createSessionOptions({
@@ -140,6 +149,8 @@ describe("AgentSession", () => {
 				systemPrompt: "Base.",
 			}),
 		);
+
+		await session.loadExtensions();
 
 		const prompt = session.agent.state.systemPrompt;
 		expect(prompt).toContain("# Available Tools");
@@ -171,6 +182,8 @@ describe("AgentSession", () => {
 		const session = new AgentSession(
 			createSessionOptions({ environment: createMockEnvironment({ tools: [tool1, tool2] }) }),
 		);
+
+		await session.loadExtensions();
 
 		expect(session.getActiveToolNames()).toHaveLength(2);
 
@@ -324,6 +337,8 @@ describe("AgentSession", () => {
 		const sm = new InMemorySessionManager();
 		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
+		await session.loadExtensions();
+
 		// Seed some messages
 		session.agent.appendMessage({
 			role: "user",
@@ -349,6 +364,7 @@ describe("AgentSession", () => {
 		const sm = createMockSessionManager();
 		const session = new AgentSession(createSessionOptions({ sessionManager: sm }));
 
+		await session.loadExtensions();
 		const result = await session.compact();
 		expect(result).toBeUndefined();
 
@@ -566,6 +582,7 @@ describe("AgentSession", () => {
 			createSessionOptions({ environment: createMockEnvironment({ tools: [tool1] }) }),
 		);
 
+		await session.loadExtensions();
 		session.registerTool(tool2);
 
 		const defs = session.getAllToolDefinitions();
@@ -790,32 +807,9 @@ describe("AgentSession", () => {
 
 		// ─── Async AgentEnvironment ───────────────────────────────────
 
-		test("createAgentSession pre-resolves async environment", async () => {
+		test("async environment tools are registered during loadExtensions", async () => {
 			const asyncEnv: AgentEnvironment = {
 				getSystemMessageAppend: async () => "async-env-append",
-				getTools: async () => [],
-			};
-
-			const { session } = await createAgentSession({
-				sessionManager: createMockSessionManager(),
-				authStorage: createMockAuthStorage(),
-				environment: asyncEnv,
-				systemPrompt: "Base.",
-			});
-
-			expect(session.agent.state.systemPrompt).toContain("Base.");
-			expect(session.agent.state.systemPrompt).toContain("async-env-append");
-
-			await session.dispose();
-		});
-
-		test("loadExtensions awaits async environment getSystemMessageAppend", async () => {
-			let callCount = 0;
-			const asyncEnv: AgentEnvironment = {
-				getSystemMessageAppend: async () => {
-					callCount++;
-					return callCount === 1 ? "first-call" : "second-call";
-				},
 				getTools: async () => [],
 			};
 
@@ -824,18 +818,14 @@ describe("AgentSession", () => {
 				authStorage: createMockAuthStorage(),
 				environment: asyncEnv,
 				systemPrompt: "Base.",
-				environmentTools: await asyncEnv.getTools(),
-				environmentAppend: await asyncEnv.getSystemMessageAppend(),
 			});
 
-			// First call was during construction (pre-resolved)
-			expect(session.agent.state.systemPrompt).toContain("first-call");
-			expect(callCount).toBe(1);
-
-			// loadExtensions should await getSystemMessageAppend again
 			await session.loadExtensions();
-			expect(session.agent.state.systemPrompt).toContain("second-call");
-			expect(callCount).toBe(2);
+
+			// The environment extension's before_agent_start handler calls
+			// getSystemMessageAppend() each turn. We verify it works by checking
+			// the extension loaded successfully (no errors thrown).
+			expect(session.getActiveToolNames()).toHaveLength(0);
 
 			await session.dispose();
 		});

--- a/packages/otter-agent/src/session/agent-session.ts
+++ b/packages/otter-agent/src/session/agent-session.ts
@@ -11,6 +11,7 @@ import type {
 	ThinkingLevel,
 } from "@mariozechner/pi-agent-core";
 import type { Api, ImageContent, Model } from "@mariozechner/pi-ai";
+import { createEnvironmentExtension } from "../environments/environment-extension.js";
 import type { CompactOptions } from "../extension-core/context.js";
 import { ExtensionRunner } from "../extension-core/extension-runner.js";
 import type { ExtensionRunnerActions } from "../extension-core/extension-runner.js";
@@ -40,10 +41,7 @@ export interface CreateAgentSessionResult {
  * but without `messages` — the factory always derives messages from
  * {@link SessionManager.buildSessionContext}.
  */
-export type CreateAgentSessionOptions = Omit<
-	AgentSessionOptions,
-	"messages" | "environmentTools" | "environmentAppend"
->;
+export type CreateAgentSessionOptions = Omit<AgentSessionOptions, "messages">;
 
 /**
  * Async factory that creates an AgentSession with session restore.
@@ -105,20 +103,12 @@ export async function createAgentSession(
 		await sessionManager.appendThinkingLevelChange(thinkingLevel);
 	}
 
-	// 9. Pre-resolve environment for async-compatible construction.
-	const [environmentTools, environmentAppend] = await Promise.all([
-		options.environment.getTools(),
-		options.environment.getSystemMessageAppend(),
-	]);
-
-	// 10. Construct and return.
+	// 9. Construct and return.
 	const session = new AgentSession({
 		...options,
 		model,
 		thinkingLevel,
 		messages: sessionContext.messages,
-		environmentTools,
-		environmentAppend,
 	});
 	return { session };
 }
@@ -149,7 +139,7 @@ export interface AgentSessionOptions {
 	/** The environment the agent operates in. */
 	environment: AgentEnvironment;
 
-	/** Base system prompt. Environment append and tool info will be added to this. */
+	/** Base system prompt. Tool info will be added to this during loadExtensions(). */
 	systemPrompt: string;
 
 	/** Initial model to use. */
@@ -174,26 +164,6 @@ export interface AgentSessionOptions {
 
 	/** Additional pi-agent-core Agent options. */
 	agentOptions?: Partial<AgentOptions>;
-
-	/**
-	 * Pre-resolved tools from the environment.
-	 *
-	 * Must be provided by all callers. Use {@link createAgentSession} for
-	 * automatic pre-resolution from an {@link AgentEnvironment} (including
-	 * async environments). Direct construction requires callers to resolve
-	 * these values themselves.
-	 */
-	environmentTools: ToolDefinition[];
-
-	/**
-	 * Pre-resolved system message append from the environment.
-	 *
-	 * Must be provided by all callers. Use {@link createAgentSession} for
-	 * automatic pre-resolution from an {@link AgentEnvironment} (including
-	 * async environments). Direct construction requires callers to resolve
-	 * these values themselves.
-	 */
-	environmentAppend: string | undefined;
 }
 
 /** Event types emitted by AgentSession (superset of pi-agent-core AgentEvent). */
@@ -210,6 +180,10 @@ type AgentSessionEventListener = (event: AgentSessionEvent) => void;
  * Wires together SessionManager, AuthStorage, AgentEnvironment, and
  * extensions. Delegates the agent loop, streaming, and tool execution
  * to the underlying Agent instance.
+ *
+ * Environment tools and system prompt append are contributed by a default
+ * environment extension that is automatically prepended during
+ * {@link loadExtensions}.
  */
 export class AgentSession {
 	/** The underlying pi-agent-core Agent instance. */
@@ -227,7 +201,6 @@ export class AgentSession {
 	private readonly _authStorage: AuthStorage;
 	private readonly _environment: AgentEnvironment;
 	private readonly _baseSystemPrompt: string;
-	private _environmentAppend: string | undefined;
 	private readonly _eventListeners: Set<AgentSessionEventListener> = new Set();
 	private readonly _extensionRunner: ExtensionRunner;
 	private _unsubscribeAgent: () => void;
@@ -254,22 +227,9 @@ export class AgentSession {
 		this._extensionRunner.setUIProvider(this.uiProvider);
 		this._extensionRunner.setModelRegistry(this.modelRegistry);
 
-		// Use pre-resolved environment values.
-		this._environmentAppend = options.environmentAppend;
-		const environmentTools = options.environmentTools;
-
-		// Register environment tools
-		for (const tool of environmentTools) {
-			this._toolDefinitions.set(tool.name, tool);
-			this._toolRegistry.set(tool.name, wrapToolDefinition(tool));
-			this._activeToolNames.add(tool.name);
-		}
-
-		// Build initial system prompt
+		// Build initial system prompt (base only — environment append and tools
+		// are added during loadExtensions() via the default environment extension).
 		const systemPrompt = this._getCurrentSystemPrompt();
-
-		// Build initial tool list
-		const tools = this._getActiveTools();
 
 		// Warn if agentOptions.initialState contains fields managed by AgentSession —
 		// they will be silently discarded. Point callers to the correct option.
@@ -292,7 +252,7 @@ export class AgentSession {
 				systemPrompt, // session values always win
 				model: options.model,
 				thinkingLevel: options.thinkingLevel ?? "off",
-				tools,
+				tools: [],
 				messages: options.messages ?? [],
 			},
 			convertToLlm: options.agentOptions?.convertToLlm ?? convertToLlm,
@@ -315,19 +275,22 @@ export class AgentSession {
 	 * Load extensions and fire session_start.
 	 * Call this after construction to initialise extensions.
 	 *
-	 * After session_start fires (extensions may have registered skills on the
-	 * environment), the system prompt is rebuilt and skill commands are registered.
+	 * A default environment extension is automatically prepended to register
+	 * the environment's tools and contribute its system prompt append via
+	 * `before_agent_start`. After session_start fires (extensions may have
+	 * registered skills on the environment), skill commands are registered.
 	 */
 	async loadExtensions(extensions?: Extension[]): Promise<void> {
 		if (extensions) {
 			this._extensions = extensions;
 		}
-		await this._extensionRunner.loadExtensions(this._extensions);
+
+		// Prepend the default environment extension so it loads first.
+		const allExtensions = [createEnvironmentExtension(this._environment), ...this._extensions];
+
+		await this._extensionRunner.loadExtensions(allExtensions);
 		await this._extensionRunner.emit({ type: "session_start" });
 
-		// Refresh the environment append now that extensions may have modified the
-		// environment (e.g. by registering skills on a SkillSupportedAgentEnvironment).
-		this._environmentAppend = await this._environment.getSystemMessageAppend();
 		this._applyToolChanges();
 		this._registerSkillCommands();
 	}
@@ -342,11 +305,13 @@ export class AgentSession {
 	 */
 	async reload(): Promise<void> {
 		this._extensionRunner.clear();
-		await this._extensionRunner.loadExtensions(this._extensions);
+
+		// Prepend the default environment extension so it loads first.
+		const allExtensions = [createEnvironmentExtension(this._environment), ...this._extensions];
+
+		await this._extensionRunner.loadExtensions(allExtensions);
 		await this._extensionRunner.emit({ type: "session_start" });
 
-		// Refresh environment append and skill commands after reload.
-		this._environmentAppend = await this._environment.getSystemMessageAppend();
 		this._applyToolChanges();
 		this._registerSkillCommands();
 	}
@@ -729,13 +694,14 @@ export class AgentSession {
 	}
 
 	/**
-	 * Build the current base system prompt (base + environment + tools).
+	 * Build the current base system prompt (base + tools).
 	 * This is the "resting" prompt that is always restored between turns.
+	 * Environment append is contributed via before_agent_start by the
+	 * default environment extension.
 	 */
 	private _getCurrentSystemPrompt(): string {
 		return buildSystemPrompt({
 			basePrompt: this._baseSystemPrompt,
-			environmentAppend: this._environmentAppend,
 			tools: this._getActiveToolDefinitions(),
 		});
 	}

--- a/packages/otter-agent/src/session/skill-commands.test.ts
+++ b/packages/otter-agent/src/session/skill-commands.test.ts
@@ -68,8 +68,6 @@ function createSession(env: AgentEnvironment): AgentSession {
 		authStorage: createMockAuthStorage(),
 		environment: env,
 		systemPrompt: "You are a test agent.",
-		environmentTools: env.getTools(),
-		environmentAppend: env.getSystemMessageAppend(),
 	});
 }
 

--- a/packages/otter-agent/src/session/system-prompt.test.ts
+++ b/packages/otter-agent/src/session/system-prompt.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import type { ToolDefinition } from "../interfaces/tool-definition.js";
 import { buildSystemPrompt, buildToolSection } from "./system-prompt.js";
 
-// ─── Helpers ──────────────────────────────────────────────────────────
+// ─── Helpers ─────────────────────────────────────────────────────────
 
 function createTool(
 	name: string,
@@ -33,15 +33,6 @@ describe("buildSystemPrompt", () => {
 		expect(result).toBe("You are a helpful assistant.");
 	});
 
-	test("base prompt with environment append", () => {
-		const result = buildSystemPrompt({
-			basePrompt: "Base.",
-			environmentAppend: "You are in Docker.",
-			tools: [],
-		});
-		expect(result).toBe("Base.\n\nYou are in Docker.");
-	});
-
 	test("base prompt with tools", () => {
 		const result = buildSystemPrompt({
 			basePrompt: "Base.",
@@ -52,38 +43,6 @@ describe("buildSystemPrompt", () => {
 		expect(result).toContain("- read: Read files");
 		expect(result).toContain("# Guidelines");
 		expect(result).toContain("- Use read for files");
-	});
-
-	test("all three components", () => {
-		const result = buildSystemPrompt({
-			basePrompt: "Base.",
-			environmentAppend: "Environment info.",
-			tools: [createTool("bash", { snippet: "Run commands" })],
-		});
-
-		const sections = result.split("\n\n");
-		expect(sections[0]).toBe("Base.");
-		expect(sections[1]).toBe("Environment info.");
-		expect(sections[2]).toContain("# Available Tools");
-		expect(sections[2]).toContain("- bash: Run commands");
-	});
-
-	test("empty environment append is excluded", () => {
-		const result = buildSystemPrompt({
-			basePrompt: "Base.",
-			environmentAppend: "",
-			tools: [],
-		});
-		expect(result).toBe("Base.");
-	});
-
-	test("undefined environment append is excluded", () => {
-		const result = buildSystemPrompt({
-			basePrompt: "Base.",
-			environmentAppend: undefined,
-			tools: [],
-		});
-		expect(result).toBe("Base.");
 	});
 
 	test("tools without snippets or guidelines produce no tool section", () => {

--- a/packages/otter-agent/src/session/system-prompt.ts
+++ b/packages/otter-agent/src/session/system-prompt.ts
@@ -1,8 +1,8 @@
 /**
  * Pure function for assembling the system prompt from its components.
  *
- * Combines the base prompt, optional environment context, and
- * active tool information (snippets + guidelines) into a single string.
+ * Combines the base prompt and active tool information (snippets + guidelines)
+ * into a single string.
  */
 import type { ToolDefinition } from "../interfaces/tool-definition.js";
 
@@ -10,21 +10,16 @@ import type { ToolDefinition } from "../interfaces/tool-definition.js";
 export interface BuildSystemPromptOptions {
 	/** The base system prompt provided by the host application. */
 	basePrompt: string;
-	/** Optional environment context appended after the base prompt. */
-	environmentAppend?: string;
 	/** Active tool definitions whose snippets and guidelines are included. */
 	tools: ToolDefinition[];
 }
 
 /**
- * Build the full system prompt from base prompt, environment context,
- * and tool information.
+ * Build the full system prompt from base prompt and tool information.
  *
  * Layout:
  * ```
  * <basePrompt>
- *
- * <environmentAppend>          (if provided)
  *
  * # Available Tools             (if any tool has a promptSnippet)
  * - toolName: snippet
@@ -35,10 +30,6 @@ export interface BuildSystemPromptOptions {
  */
 export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 	const parts: string[] = [options.basePrompt];
-
-	if (options.environmentAppend) {
-		parts.push(options.environmentAppend);
-	}
 
 	const toolSection = buildToolSection(options.tools);
 	if (toolSection) {

--- a/packages/rpc/src/rpc-handler.test.ts
+++ b/packages/rpc/src/rpc-handler.test.ts
@@ -51,14 +51,11 @@ function createSessionOptions(overrides?: {
 	systemPrompt?: string;
 	uiProvider?: import("@otter-agent/core").UIProvider;
 }) {
-	const environment = overrides?.environment ?? createMockEnvironment();
 	return {
 		sessionManager: overrides?.sessionManager ?? createMockSessionManager(),
 		authStorage: overrides?.authStorage ?? createMockAuthStorage(),
-		environment,
+		environment: overrides?.environment ?? createMockEnvironment(),
 		systemPrompt: overrides?.systemPrompt ?? "Test prompt",
-		environmentTools: environment.getTools(),
-		environmentAppend: environment.getSystemMessageAppend(),
 		...(overrides?.uiProvider !== undefined ? { uiProvider: overrides.uiProvider } : {}),
 	};
 }


### PR DESCRIPTION
## Summary

Closes #116

Removes `environmentTools` and `environmentAppend` from `AgentSessionOptions`. Instead, a default environment extension is automatically prepended during `loadExtensions()`, which:

- Registers the environment's tools via `api.registerTool()` during init
- Appends the environment's system message via the `before_agent_start` event (queried fresh each turn, matching pi-coding-agent's pattern)

## Changes

| File | Change |
|------|--------|
| `environments/environment-extension.ts` | **New** — `createEnvironmentExtension()` factory |
| `environments/environment-extension.test.ts` | **New** — 11 tests |
| `environments/index.ts` | Export `createEnvironmentExtension` |
| `src/index.ts` | Export `createEnvironmentExtension` |
| `session/agent-session.ts` | Removed `environmentTools`/`environmentAppend` from options; `loadExtensions()` and `reload()` auto-prepend env extension |
| `session/system-prompt.ts` | Removed `environmentAppend` parameter |
| `session/agent-session.test.ts` | Updated helpers and tests |
| `session/system-prompt.test.ts` | Removed `environmentAppend` tests |
| `session/skill-commands.test.ts` | Updated helper |
| `rpc/src/rpc-handler.test.ts` | Updated helper |

## Stats

- **10 files changed**, +367 / -174 lines
- **575 tests pass** (including 11 new environment extension tests)
- Lint clean