### PR TITLE
feat: add @otter-agent/auth-storage-registry and @otter-agent/session-manager-registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,6 +1516,10 @@
 				"node": ">= 20.19.0"
 			}
 		},
+		"node_modules/@otter-agent/auth-storage-registry": {
+			"resolved": "packages/auth-storage-registry",
+			"link": true
+		},
 		"node_modules/@otter-agent/core": {
 			"resolved": "packages/otter-agent",
 			"link": true
@@ -1530,6 +1534,10 @@
 		},
 		"node_modules/@otter-agent/rpc": {
 			"resolved": "packages/rpc",
+			"link": true
+		},
+		"node_modules/@otter-agent/session-manager-registry": {
+			"resolved": "packages/session-manager-registry",
 			"link": true
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -5130,6 +5138,14 @@
 				"zod": "^3.25.28 || ^4"
 			}
 		},
+		"packages/auth-storage-registry": {
+			"name": "@otter-agent/auth-storage-registry",
+			"version": "0.0.1",
+			"dependencies": {
+				"@otter-agent/core": "*",
+				"@sinclair/typebox": "^0.34.0"
+			}
+		},
 		"packages/environment-registry": {
 			"name": "@otter-agent/environment-registry",
 			"version": "0.0.1",
@@ -5174,6 +5190,16 @@
 			},
 			"bin": {
 				"otter": "dist/cli/cli.js"
+			}
+		},
+		"packages/session-manager-registry": {
+			"name": "@otter-agent/session-manager-registry",
+			"version": "0.0.1",
+			"dependencies": {
+				"@mariozechner/pi-agent-core": "^0.64.0",
+				"@mariozechner/pi-ai": "^0.64.0",
+				"@otter-agent/core": "*",
+				"@sinclair/typebox": "^0.34.0"
 			}
 		}
 	}

--- a/packages/auth-storage-registry/package.json
+++ b/packages/auth-storage-registry/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@otter-agent/auth-storage-registry",
+	"version": "0.0.1",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": ["dist/"],
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc",
+		"test": "vitest run",
+		"dev": "tsc --watch"
+	},
+	"dependencies": {
+		"@otter-agent/core": "*",
+		"@sinclair/typebox": "^0.34.0"
+	}
+}

--- a/packages/auth-storage-registry/src/auth-storages/in-memory/in-memory-auth-storage.test.ts
+++ b/packages/auth-storage-registry/src/auth-storages/in-memory/in-memory-auth-storage.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { InMemoryAuthStorage } from "./index.js";
+
+// ─── InMemoryAuthStorage — direct construction ─────────────────────────
+
+describe("InMemoryAuthStorage", () => {
+	test("returns the key for a known provider", async () => {
+		const auth = new InMemoryAuthStorage({ anthropic: "sk-ant-123" });
+		expect(await auth.getApiKey("anthropic")).toBe("sk-ant-123");
+	});
+
+	test("returns undefined for an unknown provider", async () => {
+		const auth = new InMemoryAuthStorage({ anthropic: "sk-ant-123" });
+		expect(await auth.getApiKey("openai")).toBeUndefined();
+	});
+
+	test("returns undefined for all providers when created with no keys", async () => {
+		const auth = new InMemoryAuthStorage();
+		expect(await auth.getApiKey("anthropic")).toBeUndefined();
+	});
+
+	test("supports multiple providers", async () => {
+		const auth = new InMemoryAuthStorage({
+			anthropic: "sk-ant-123",
+			openai: "sk-oai-456",
+		});
+		expect(await auth.getApiKey("anthropic")).toBe("sk-ant-123");
+		expect(await auth.getApiKey("openai")).toBe("sk-oai-456");
+	});
+
+	test("each instance is independent", async () => {
+		const auth1 = new InMemoryAuthStorage({ anthropic: "key-1" });
+		const auth2 = new InMemoryAuthStorage({ anthropic: "key-2" });
+		expect(await auth1.getApiKey("anthropic")).toBe("key-1");
+		expect(await auth2.getApiKey("anthropic")).toBe("key-2");
+	});
+
+	test("instanceof InMemoryAuthStorage is true for direct construction", () => {
+		const auth = new InMemoryAuthStorage();
+		expect(auth instanceof InMemoryAuthStorage).toBe(true);
+	});
+});

--- a/packages/auth-storage-registry/src/auth-storages/in-memory/index.ts
+++ b/packages/auth-storage-registry/src/auth-storages/in-memory/index.ts
@@ -14,18 +14,6 @@ export class InMemoryAuthStorage implements AuthStorage {
 	}
 }
 
-/**
- * Creates a new read-only in-memory {@link AuthStorage} seeded with the
- * provided provider-to-API-key map. Returns `undefined` for any provider
- * not present in the initial map.
- *
- * @param keys - Optional map of provider identifier to API key
- *   (e.g., `{ anthropic: "sk-ant-...", openai: "sk-..." }`).
- */
-export function createInMemoryAuthStorage(keys?: Record<string, string>): InMemoryAuthStorage {
-	return new InMemoryAuthStorage(keys);
-}
-
 // ─── ComponentTemplate ────────────────────────────────────────────────────────
 
 /** TypeBox schema for {@link InMemoryAuthStorage} options. */
@@ -45,5 +33,7 @@ export const InMemoryAuthStorageTemplate: ComponentTemplate<
 > = {
 	configSchema: () => InMemoryAuthStorageOptionsSchema,
 	defaultConfig: () => ({}),
-	build: ({ keys }) => new InMemoryAuthStorage(keys),
+	build({ keys }) {
+		return new InMemoryAuthStorage(keys);
+	},
 };

--- a/packages/auth-storage-registry/src/auth-storages/in-memory/index.ts
+++ b/packages/auth-storage-registry/src/auth-storages/in-memory/index.ts
@@ -1,0 +1,49 @@
+import type { AuthStorage } from "@otter-agent/core";
+import type { ComponentTemplate } from "@otter-agent/core";
+import { Type } from "@sinclair/typebox";
+
+export class InMemoryAuthStorage implements AuthStorage {
+	private readonly keys: ReadonlyMap<string, string>;
+
+	constructor(keys: Record<string, string> = {}) {
+		this.keys = new Map(Object.entries(keys));
+	}
+
+	async getApiKey(provider: string): Promise<string | undefined> {
+		return this.keys.get(provider);
+	}
+}
+
+/**
+ * Creates a new read-only in-memory {@link AuthStorage} seeded with the
+ * provided provider-to-API-key map. Returns `undefined` for any provider
+ * not present in the initial map.
+ *
+ * @param keys - Optional map of provider identifier to API key
+ *   (e.g., `{ anthropic: "sk-ant-...", openai: "sk-..." }`).
+ */
+export function createInMemoryAuthStorage(keys?: Record<string, string>): InMemoryAuthStorage {
+	return new InMemoryAuthStorage(keys);
+}
+
+// ─── ComponentTemplate ────────────────────────────────────────────────────────
+
+/** TypeBox schema for {@link InMemoryAuthStorage} options. */
+export const InMemoryAuthStorageOptionsSchema = Type.Object({
+	/** Optional map of provider identifier to API key. */
+	keys: Type.Optional(Type.Record(Type.String(), Type.String())),
+});
+
+/**
+ * {@link ComponentTemplate} for {@link InMemoryAuthStorage}.
+ *
+ * Builds an in-memory auth storage seeded with an optional key map.
+ */
+export const InMemoryAuthStorageTemplate: ComponentTemplate<
+	typeof InMemoryAuthStorageOptionsSchema,
+	InMemoryAuthStorage
+> = {
+	configSchema: () => InMemoryAuthStorageOptionsSchema,
+	defaultConfig: () => ({}),
+	build: ({ keys }) => new InMemoryAuthStorage(keys),
+};

--- a/packages/auth-storage-registry/src/index.ts
+++ b/packages/auth-storage-registry/src/index.ts
@@ -1,0 +1,27 @@
+// Re-export AuthStorage type from core.
+export type { AuthStorage } from "@otter-agent/core";
+
+// Public exports for the in-memory auth storage.
+export {
+	InMemoryAuthStorage,
+	InMemoryAuthStorageOptionsSchema,
+	InMemoryAuthStorageTemplate,
+} from "./auth-storages/in-memory/index.js";
+
+/**
+ * Options for {@link buildAuthStorage}.
+ */
+export interface BuildAuthStorageOptions {
+	/** The registered auth storage name (e.g. "in-memory"). */
+	name: string;
+	/**
+	 * Configuration to merge with the auth storage template's defaults.
+	 * Pass null or undefined to use defaults as-is.
+	 */
+	config: unknown;
+}
+
+// Eagerly populate the registry with built-in auth storages.
+import "./registry/register-auth-storages.js";
+
+export { buildAuthStorage } from "./registry/registry.js";

--- a/packages/auth-storage-registry/src/registry/register-auth-storages.ts
+++ b/packages/auth-storage-registry/src/registry/register-auth-storages.ts
@@ -1,0 +1,4 @@
+import { InMemoryAuthStorageTemplate } from "../auth-storages/in-memory/index.js";
+import { registerAuthStorage } from "./registry.js";
+
+registerAuthStorage("in-memory", InMemoryAuthStorageTemplate);

--- a/packages/auth-storage-registry/src/registry/registry.test.ts
+++ b/packages/auth-storage-registry/src/registry/registry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildAuthStorage } from "../index.js";
+
+describe("buildAuthStorage", () => {
+	it("builds 'in-memory' auth storage with default config", () => {
+		const authStorage = buildAuthStorage({ name: "in-memory", config: {} });
+		expect(authStorage).toBeDefined();
+		expect(typeof authStorage.getApiKey).toBe("function");
+	});
+
+	it("builds 'in-memory' auth storage with null config (uses defaults)", () => {
+		const authStorage = buildAuthStorage({ name: "in-memory", config: null });
+		expect(authStorage).toBeDefined();
+	});
+
+	it("builds 'in-memory' auth storage with undefined config (uses defaults)", () => {
+		const authStorage = buildAuthStorage({ name: "in-memory", config: undefined });
+		expect(authStorage).toBeDefined();
+	});
+
+	it("throws Error for unknown auth storage name", () => {
+		expect(() => buildAuthStorage({ name: "nonexistent", config: {} })).toThrow(
+			'Unknown auth storage "nonexistent". Registered auth storages: in-memory',
+		);
+	});
+});

--- a/packages/auth-storage-registry/src/registry/registry.ts
+++ b/packages/auth-storage-registry/src/registry/registry.ts
@@ -1,0 +1,57 @@
+import type { AuthStorage, ComponentTemplate } from "@otter-agent/core";
+import { validateComponentConfig } from "@otter-agent/core";
+import type { TSchema } from "@sinclair/typebox";
+import type { BuildAuthStorageOptions } from "../index.js";
+
+/**
+ * Internal registry mapping auth storage names to their templates.
+ */
+const registry = new Map<string, ComponentTemplate<TSchema, AuthStorage>>();
+
+/**
+ * Register an auth storage template under the given name.
+ *
+ * Internal-only — not exported from the package.
+ */
+export function registerAuthStorage(
+	name: string,
+	template: ComponentTemplate<TSchema, AuthStorage>,
+): void {
+	registry.set(name, template);
+}
+
+/**
+ * Build an {@link AuthStorage} by name.
+ *
+ * Workflow:
+ * 1. Look up the registered template by name. Throws if not found.
+ * 2. Merge the provided config with the template's defaults.
+ *    If config is null or undefined, uses defaults as-is.
+ * 3. Validate the merged config against the template's TypeBox schema.
+ * 4. Build and return the AuthStorage instance.
+ *
+ * @param options - The auth storage name and optional config.
+ * @returns A built AuthStorage instance.
+ * @throws {Error} If no template is registered under the given name.
+ * @throws {import("@otter-agent/core").ComponentConfigValidationError} If config validation fails.
+ */
+export function buildAuthStorage(options: BuildAuthStorageOptions): AuthStorage {
+	const template = registry.get(options.name);
+
+	if (!template) {
+		const registered = [...registry.keys()].join(", ");
+		throw new Error(
+			`Unknown auth storage "${options.name}". Registered auth storages: ${registered}`,
+		);
+	}
+
+	const rawConfig =
+		options.config !== null &&
+		options.config !== undefined &&
+		typeof options.config === "object" &&
+		!Array.isArray(options.config)
+			? (options.config as Record<string, unknown>)
+			: {};
+
+	return validateComponentConfig(template, rawConfig);
+}

--- a/packages/auth-storage-registry/tsconfig.json
+++ b/packages/auth-storage-registry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/packages/session-manager-registry/package.json
+++ b/packages/session-manager-registry/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@otter-agent/session-manager-registry",
+	"version": "0.0.1",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": ["dist/"],
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc",
+		"test": "vitest run",
+		"dev": "tsc --watch"
+	},
+	"dependencies": {
+		"@mariozechner/pi-agent-core": "^0.64.0",
+		"@mariozechner/pi-ai": "^0.64.0",
+		"@otter-agent/core": "*",
+		"@sinclair/typebox": "^0.34.0"
+	}
+}

--- a/packages/session-manager-registry/src/index.ts
+++ b/packages/session-manager-registry/src/index.ts
@@ -1,0 +1,28 @@
+// Re-export SessionManager type from core.
+export type { SessionManager } from "@otter-agent/core";
+
+// Public exports for the in-memory session manager.
+export {
+	InMemorySessionManager,
+	InMemorySessionManagerOptionsSchema,
+	InMemorySessionManagerTemplate,
+	createInMemorySessionManager,
+} from "./session-managers/in-memory/index.js";
+
+/**
+ * Options for {@link buildSessionManager}.
+ */
+export interface BuildSessionManagerOptions {
+	/** The registered session manager name (e.g. "in-memory"). */
+	name: string;
+	/**
+	 * Configuration to merge with the session manager template's defaults.
+	 * Pass null or undefined to use defaults as-is.
+	 */
+	config: unknown;
+}
+
+// Eagerly populate the registry with built-in session managers.
+import "./registry/register-session-managers.js";
+
+export { buildSessionManager } from "./registry/registry.js";

--- a/packages/session-manager-registry/src/index.ts
+++ b/packages/session-manager-registry/src/index.ts
@@ -6,7 +6,6 @@ export {
 	InMemorySessionManager,
 	InMemorySessionManagerOptionsSchema,
 	InMemorySessionManagerTemplate,
-	createInMemorySessionManager,
 } from "./session-managers/in-memory/index.js";
 
 /**

--- a/packages/session-manager-registry/src/registry/register-session-managers.ts
+++ b/packages/session-manager-registry/src/registry/register-session-managers.ts
@@ -1,0 +1,4 @@
+import { InMemorySessionManagerTemplate } from "../session-managers/in-memory/index.js";
+import { registerSessionManager } from "./registry.js";
+
+registerSessionManager("in-memory", InMemorySessionManagerTemplate);

--- a/packages/session-manager-registry/src/registry/registry.test.ts
+++ b/packages/session-manager-registry/src/registry/registry.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionManager } from "../index.js";
+
+describe("buildSessionManager", () => {
+	it("builds 'in-memory' session manager with default config", () => {
+		const sessionManager = buildSessionManager({ name: "in-memory", config: {} });
+		expect(sessionManager).toBeDefined();
+		expect(typeof sessionManager.appendMessage).toBe("function");
+		expect(typeof sessionManager.buildSessionContext).toBe("function");
+	});
+
+	it("builds 'in-memory' session manager with null config (uses defaults)", () => {
+		const sessionManager = buildSessionManager({ name: "in-memory", config: null });
+		expect(sessionManager).toBeDefined();
+	});
+
+	it("builds 'in-memory' session manager with undefined config (uses defaults)", () => {
+		const sessionManager = buildSessionManager({ name: "in-memory", config: undefined });
+		expect(sessionManager).toBeDefined();
+	});
+
+	it("throws Error for unknown session manager name", () => {
+		expect(() => buildSessionManager({ name: "nonexistent", config: {} })).toThrow(
+			'Unknown session manager "nonexistent". Registered session managers: in-memory',
+		);
+	});
+});

--- a/packages/session-manager-registry/src/registry/registry.ts
+++ b/packages/session-manager-registry/src/registry/registry.ts
@@ -1,0 +1,57 @@
+import type { ComponentTemplate, SessionManager } from "@otter-agent/core";
+import { validateComponentConfig } from "@otter-agent/core";
+import type { TSchema } from "@sinclair/typebox";
+import type { BuildSessionManagerOptions } from "../index.js";
+
+/**
+ * Internal registry mapping session manager names to their templates.
+ */
+const registry = new Map<string, ComponentTemplate<TSchema, SessionManager>>();
+
+/**
+ * Register a session manager template under the given name.
+ *
+ * Internal-only — not exported from the package.
+ */
+export function registerSessionManager(
+	name: string,
+	template: ComponentTemplate<TSchema, SessionManager>,
+): void {
+	registry.set(name, template);
+}
+
+/**
+ * Build a {@link SessionManager} by name.
+ *
+ * Workflow:
+ * 1. Look up the registered template by name. Throws if not found.
+ * 2. Merge the provided config with the template's defaults.
+ *    If config is null or undefined, uses defaults as-is.
+ * 3. Validate the merged config against the template's TypeBox schema.
+ * 4. Build and return the SessionManager instance.
+ *
+ * @param options - The session manager name and optional config.
+ * @returns A built SessionManager instance.
+ * @throws {Error} If no template is registered under the given name.
+ * @throws {import("@otter-agent/core").ComponentConfigValidationError} If config validation fails.
+ */
+export function buildSessionManager(options: BuildSessionManagerOptions): SessionManager {
+	const template = registry.get(options.name);
+
+	if (!template) {
+		const registered = [...registry.keys()].join(", ");
+		throw new Error(
+			`Unknown session manager "${options.name}". Registered session managers: ${registered}`,
+		);
+	}
+
+	const rawConfig =
+		options.config !== null &&
+		options.config !== undefined &&
+		typeof options.config === "object" &&
+		!Array.isArray(options.config)
+			? (options.config as Record<string, unknown>)
+			: {};
+
+	return validateComponentConfig(template, rawConfig);
+}

--- a/packages/session-manager-registry/src/session-managers/in-memory/in-memory-session-manager.test.ts
+++ b/packages/session-manager-registry/src/session-managers/in-memory/in-memory-session-manager.test.ts
@@ -1,0 +1,232 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, test } from "vitest";
+import { InMemorySessionManager } from "./index.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function userMsg(text: string): AgentMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: 1,
+	} as AgentMessage;
+}
+
+function assistantMsg(text: string): AgentMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		timestamp: 2,
+	} as AgentMessage;
+}
+
+// ─── Entry uniqueness & ordering ─────────────────────────────────────
+
+describe("InMemorySessionManager", () => {
+	describe("entry IDs", () => {
+		test("appendMessage returns unique sequential IDs", async () => {
+			const sm = new InMemorySessionManager();
+			const id1 = await sm.appendMessage(userMsg("a"));
+			const id2 = await sm.appendMessage(userMsg("b"));
+			expect(id1).toBe("1");
+			expect(id2).toBe("2");
+			expect(id1).not.toBe(id2);
+		});
+
+		test("IDs are unique across different entry types", async () => {
+			const sm = new InMemorySessionManager();
+			const id1 = await sm.appendMessage(userMsg("a"));
+			const id2 = await sm.appendLabel("bookmark", id1);
+			const id3 = await sm.compact();
+			expect(id1).toBe("1");
+			expect(id2).toBe("2");
+			expect(id3).toBe("3");
+		});
+	});
+
+	// ─── getEntries ─────────────────────────────────────────────────
+
+	describe("getEntries", () => {
+		test("returns a snapshot (not a live reference)", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendMessage(userMsg("a"));
+			const entries1 = await sm.getEntries();
+			await sm.appendMessage(userMsg("b"));
+			const entries2 = await sm.getEntries();
+			expect(entries1).toHaveLength(1);
+			expect(entries2).toHaveLength(2);
+		});
+
+		test("returns all entry types verbatim", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendMessage(userMsg("hello"));
+			await sm.appendCustomEntry("my-ext", { foo: "bar" });
+			await sm.appendModelChange({ provider: "anthropic", modelId: "claude-3" }, "low");
+			await sm.appendLabel("important", "1");
+
+			const entries = await sm.getEntries();
+			expect(entries).toHaveLength(4);
+			expect(entries[0].type).toBe("message");
+			expect(entries[1].type).toBe("customEntry");
+			expect(entries[2].type).toBe("modelChange");
+			expect(entries[3].type).toBe("label");
+		});
+	});
+
+	// ─── buildSessionContext — no compaction ────────────────────────
+
+	describe("buildSessionContext (no compaction)", () => {
+		test("returns empty context for new session", async () => {
+			const sm = new InMemorySessionManager();
+			const ctx = await sm.buildSessionContext();
+			expect(ctx.messages).toEqual([]);
+			expect(ctx.model).toBeNull();
+			expect(ctx.thinkingLevel).toBe("off");
+		});
+
+		test("includes all appended messages in order", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendMessage(userMsg("hello"));
+			await sm.appendMessage(assistantMsg("hi there"));
+			await sm.appendMessage(userMsg("bye"));
+
+			const ctx = await sm.buildSessionContext();
+			expect(ctx.messages).toHaveLength(3);
+			expect((ctx.messages[0] as AgentMessage).content).toEqual([{ type: "text", text: "hello" }]);
+			expect((ctx.messages[1] as AgentMessage).content).toEqual([
+				{ type: "text", text: "hi there" },
+			]);
+			expect((ctx.messages[2] as AgentMessage).content).toEqual([{ type: "text", text: "bye" }]);
+		});
+
+		test("includes custom message entries in context", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendMessage(userMsg("question"));
+			await sm.appendCustomMessageEntry("system_notice", "Processing...", true);
+
+			const ctx = await sm.buildSessionContext();
+			expect(ctx.messages).toHaveLength(2);
+			// Second message should be a custom message
+			expect((ctx.messages[1] as AgentMessage).role).toBe("custom");
+		});
+
+		test("excludes metadata entries (modelChange, thinkingLevelChange, label, customEntry) from messages", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendMessage(userMsg("hello"));
+			await sm.appendModelChange({ provider: "anthropic", modelId: "claude-3" }, "low");
+			await sm.appendThinkingLevelChange("high");
+			await sm.appendLabel("bookmark", "1");
+			await sm.appendCustomEntry("my-ext", { state: {} });
+			await sm.appendMessage(userMsg("world"));
+
+			const ctx = await sm.buildSessionContext();
+			expect(ctx.messages).toHaveLength(2);
+		});
+
+		test("extracts latest model and thinking level from metadata entries", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendModelChange({ provider: "openai", modelId: "gpt-4" }, "off");
+			await sm.appendMessage(userMsg("switch"));
+			await sm.appendModelChange({ provider: "anthropic", modelId: "claude-3" }, "low");
+			await sm.appendThinkingLevelChange("high");
+
+			const ctx = await sm.buildSessionContext();
+			expect(ctx.model).toEqual({ provider: "anthropic", modelId: "claude-3" });
+			expect(ctx.thinkingLevel).toBe("high");
+		});
+
+		test("thinkingLevel defaults to off when no metadata entries exist", async () => {
+			const sm = new InMemorySessionManager();
+			const ctx = await sm.buildSessionContext();
+			expect(ctx.thinkingLevel).toBe("off");
+		});
+
+		test("model defaults to null when no metadata entries exist", async () => {
+			const sm = new InMemorySessionManager();
+			const ctx = await sm.buildSessionContext();
+			expect(ctx.model).toBeNull();
+		});
+	});
+
+	// ─── buildSessionContext — with compaction ──────────────────────
+
+	describe("buildSessionContext (with compaction)", () => {
+		test("full compaction (no summary, no firstKeptEntryId) discards all pre-compaction messages", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendMessage(userMsg("old 1"));
+			await sm.appendMessage(userMsg("old 2"));
+			await sm.compact();
+			await sm.appendMessage(userMsg("new 1"));
+
+			const ctx = await sm.buildSessionContext();
+			expect(ctx.messages).toHaveLength(1);
+			expect((ctx.messages[0] as AgentMessage).content).toEqual([{ type: "text", text: "new 1" }]);
+		});
+
+		test("compaction with summary prepends summary message", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendMessage(userMsg("old"));
+			await sm.compact("Summarized conversation", undefined, 500);
+			await sm.appendMessage(userMsg("new"));
+
+			const ctx = await sm.buildSessionContext();
+			expect(ctx.messages).toHaveLength(2);
+			// Summary message has role compactionSummary
+			expect((ctx.messages[0] as AgentMessage).role).toBe("compactionSummary");
+			expect((ctx.messages[1] as AgentMessage).content).toEqual([{ type: "text", text: "new" }]);
+		});
+
+		test("compaction with firstKeptEntryId keeps messages from that entry onward (excluding compaction entry)", async () => {
+			const sm = new InMemorySessionManager();
+			const id1 = await sm.appendMessage(userMsg("msg 1"));
+			await sm.appendMessage(userMsg("msg 2"));
+			const id3 = await sm.appendMessage(userMsg("msg 3"));
+			await sm.appendMessage(userMsg("msg 4"));
+			// Compact but keep from msg 3 onward
+			await sm.compact("summary", id3);
+
+			const ctx = await sm.buildSessionContext();
+			// Summary + msg 3 + msg 4
+			expect(ctx.messages).toHaveLength(3);
+			expect((ctx.messages[1] as AgentMessage).content).toEqual([{ type: "text", text: "msg 3" }]);
+			expect((ctx.messages[2] as AgentMessage).content).toEqual([{ type: "text", text: "msg 4" }]);
+		});
+
+		test("latest compaction wins when multiple compactions exist", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendMessage(userMsg("a"));
+			await sm.compact("first summary");
+			await sm.appendMessage(userMsg("b"));
+			await sm.compact("second summary");
+			await sm.appendMessage(userMsg("c"));
+
+			const ctx = await sm.buildSessionContext();
+			// Second summary + msg c (msg a and b are behind both compactions)
+			expect(ctx.messages).toHaveLength(2);
+			expect((ctx.messages[0] as AgentMessage).role).toBe("compactionSummary");
+			expect((ctx.messages[1] as AgentMessage).content).toEqual([{ type: "text", text: "c" }]);
+		});
+
+		test("messages after compaction are always included", async () => {
+			const sm = new InMemorySessionManager();
+			await sm.appendMessage(userMsg("before"));
+			await sm.compact("summary", undefined, 100);
+			await sm.appendMessage(userMsg("after 1"));
+			await sm.appendCustomMessageEntry("notice", "pinned", true);
+			await sm.appendMessage(userMsg("after 2"));
+
+			const ctx = await sm.buildSessionContext();
+			// summary + after1 + custom notice + after2
+			expect(ctx.messages).toHaveLength(4);
+		});
+	});
+
+	// ─── Construction ────────────────────────────────────────────────
+
+	describe("construction", () => {
+		test("returns an InMemorySessionManager instance", () => {
+			const sm = new InMemorySessionManager();
+			expect(sm).toBeInstanceOf(InMemorySessionManager);
+		});
+	});
+});

--- a/packages/session-manager-registry/src/session-managers/in-memory/index.ts
+++ b/packages/session-manager-registry/src/session-managers/in-memory/index.ts
@@ -1,0 +1,197 @@
+import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
+import type {
+	ComponentTemplate,
+	Entry,
+	EntryId,
+	SessionContext,
+	SessionManager,
+} from "@otter-agent/core";
+import { createCompactionSummaryMessage, createCustomMessage } from "@otter-agent/core";
+import { Type } from "@sinclair/typebox";
+
+export class InMemorySessionManager implements SessionManager {
+	private readonly entries: Entry[] = [];
+	private nextId = 1;
+
+	private generateId(): EntryId {
+		return String(this.nextId++);
+	}
+
+	async appendMessage(message: AgentMessage): Promise<EntryId> {
+		const id = this.generateId();
+		this.entries.push({ type: "message", id, message });
+		return id;
+	}
+
+	async appendCustomMessageEntry(
+		customType: string,
+		content: string | (TextContent | ImageContent)[],
+		display: boolean,
+		details?: unknown,
+	): Promise<EntryId> {
+		const id = this.generateId();
+		this.entries.push({
+			type: "customMessage",
+			id,
+			customType,
+			content,
+			display,
+			details,
+			timestamp: Date.now(),
+		});
+		return id;
+	}
+
+	async appendCustomEntry(customType: string, data?: unknown): Promise<EntryId> {
+		const id = this.generateId();
+		this.entries.push({ type: "customEntry", id, customType, data });
+		return id;
+	}
+
+	async appendModelChange(
+		model: { provider: string; modelId: string },
+		thinkingLevel: string,
+	): Promise<EntryId> {
+		const id = this.generateId();
+		this.entries.push({ type: "modelChange", id, model, thinkingLevel });
+		return id;
+	}
+
+	async appendThinkingLevelChange(thinkingLevel: string): Promise<EntryId> {
+		const id = this.generateId();
+		this.entries.push({ type: "thinkingLevelChange", id, thinkingLevel });
+		return id;
+	}
+
+	async compact(
+		summary?: string,
+		firstKeptEntryId?: EntryId,
+		tokensBefore = 0,
+		details?: unknown,
+	): Promise<EntryId> {
+		const id = this.generateId();
+		this.entries.push({
+			type: "compaction",
+			id,
+			summary,
+			firstKeptEntryId,
+			tokensBefore,
+			details,
+		});
+		return id;
+	}
+
+	async appendLabel(label: string, targetEntryId: EntryId): Promise<EntryId> {
+		const id = this.generateId();
+		this.entries.push({ type: "label", id, label, targetEntryId });
+		return id;
+	}
+
+	async getEntries(): Promise<Entry[]> {
+		return [...this.entries];
+	}
+
+	async buildSessionContext(): Promise<SessionContext> {
+		// Find the latest compaction entry.
+		let latestCompaction: Extract<Entry, { type: "compaction" }> | undefined;
+		for (const entry of this.entries) {
+			if (entry.type === "compaction") {
+				latestCompaction = entry;
+			}
+		}
+
+		// Collect messages.
+		let messages: AgentMessage[];
+
+		if (latestCompaction !== undefined) {
+			const compaction = latestCompaction;
+			const compactionIndex = this.entries.indexOf(latestCompaction);
+
+			// Build the message list starting with an optional summary.
+			messages = [];
+
+			if (compaction.summary !== undefined) {
+				messages.push(createCompactionSummaryMessage(compaction.summary, compaction.tokensBefore));
+			}
+
+			if (compaction.firstKeptEntryId !== undefined) {
+				// Include message-bearing entries from firstKeptEntryId onward,
+				// but stop before (and excluding) the compaction entry itself.
+				const firstKeptIndex = this.entries.findIndex((e) => e.id === compaction.firstKeptEntryId);
+				if (firstKeptIndex !== -1) {
+					const tail = this.entries.slice(firstKeptIndex, compactionIndex);
+					messages.push(...this.extractMessages(tail));
+				}
+			}
+
+			// Include any message-bearing entries after the compaction entry.
+			const afterCompaction = this.entries.slice(compactionIndex + 1);
+			messages.push(...this.extractMessages(afterCompaction));
+		} else {
+			messages = this.extractMessages(this.entries);
+		}
+
+		// Extract the latest model and thinking level from metadata entries.
+		let model: { provider: string; modelId: string } | null = null;
+		let thinkingLevel = "off";
+
+		for (const entry of this.entries) {
+			if (entry.type === "modelChange") {
+				model = entry.model;
+				thinkingLevel = entry.thinkingLevel;
+			} else if (entry.type === "thinkingLevelChange") {
+				thinkingLevel = entry.thinkingLevel;
+			}
+		}
+
+		return { messages, thinkingLevel: thinkingLevel as ThinkingLevel, model };
+	}
+
+	private extractMessages(entries: Entry[]): AgentMessage[] {
+		const messages: AgentMessage[] = [];
+		for (const entry of entries) {
+			if (entry.type === "message") {
+				messages.push(entry.message);
+			} else if (entry.type === "customMessage") {
+				messages.push(
+					createCustomMessage(
+						entry.customType,
+						entry.content,
+						entry.display,
+						entry.details,
+						entry.timestamp,
+					),
+				);
+			}
+		}
+		return messages;
+	}
+}
+
+/**
+ * Creates a new in-memory {@link SessionManager} that stores all entries in
+ * memory without any filesystem persistence.
+ */
+export function createInMemorySessionManager(): InMemorySessionManager {
+	return new InMemorySessionManager();
+}
+
+// ─── ComponentTemplate ────────────────────────────────────────────────────────
+
+/** TypeBox schema for {@link InMemorySessionManager} options. */
+export const InMemorySessionManagerOptionsSchema = Type.Object({});
+
+/**
+ * {@link ComponentTemplate} for {@link InMemorySessionManager}.
+ *
+ * Builds an in-memory session manager with no configuration.
+ */
+export const InMemorySessionManagerTemplate: ComponentTemplate<
+	typeof InMemorySessionManagerOptionsSchema,
+	InMemorySessionManager
+> = {
+	configSchema: () => InMemorySessionManagerOptionsSchema,
+	defaultConfig: () => ({}),
+	build: (_config) => new InMemorySessionManager(),
+};

--- a/packages/session-manager-registry/src/session-managers/in-memory/index.ts
+++ b/packages/session-manager-registry/src/session-managers/in-memory/index.ts
@@ -169,14 +169,6 @@ export class InMemorySessionManager implements SessionManager {
 	}
 }
 
-/**
- * Creates a new in-memory {@link SessionManager} that stores all entries in
- * memory without any filesystem persistence.
- */
-export function createInMemorySessionManager(): InMemorySessionManager {
-	return new InMemorySessionManager();
-}
-
 // ─── ComponentTemplate ────────────────────────────────────────────────────────
 
 /** TypeBox schema for {@link InMemorySessionManager} options. */
@@ -193,5 +185,7 @@ export const InMemorySessionManagerTemplate: ComponentTemplate<
 > = {
 	configSchema: () => InMemorySessionManagerOptionsSchema,
 	defaultConfig: () => ({}),
-	build: (_config) => new InMemorySessionManager(),
+	build() {
+		return new InMemorySessionManager();
+	},
 };

--- a/packages/session-manager-registry/tsconfig.json
+++ b/packages/session-manager-registry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #125

Adds two new registry packages following the established pattern from `environment-registry` and `extension-registry`.

### `@otter-agent/auth-storage-registry`
- Registry with `buildAuthStorage({ name, config })` factory
- `in-memory` built-in registered via side-effect import
- `InMemoryAuthStorage` class, TypeBox schema, and `ComponentTemplate`
- 4 registry tests + 6 implementation tests

### `@otter-agent/session-manager-registry`
- Registry with `buildSessionManager({ name, config })` factory
- `in-memory` built-in registered via side-effect import
- `InMemorySessionManager` class, TypeBox schema, and `ComponentTemplate`
- 4 registry tests + 17 implementation tests

### Design decisions
- In-memory implementations are duplicated from their current locations (`@otter-agent/core` and `@otter-agent/rpc`). Consolidation is left for future work.
- No convenience factory functions exported — templates use constructors directly, matching all other registry templates.
- No changes to existing packages — no CLI integration, no refactoring.
- Implementation tests ported from originals so these packages carry full coverage as their canonical home.

### Verification
- `npm run build` — all 6 packages compile
- `npm run lint` — passes
- `npm test` — 493/493 tests pass (23 new)